### PR TITLE
Remove commit 774b45c (8.0.3 is broken in CN)

### DIFF
--- a/background/translationService.js
+++ b/background/translationService.js
@@ -263,7 +263,7 @@ var translationService = {}
         return translateHTML(
             "google",
             targetLanguage,
-            `https://translate.googleapis.${"zh-cn" === navigator.language.toLowerCase() ? "cn" : "com"}/translate_a/t?anno=3&client=te&v=1.0&format=html&sl=auto&tl=` + targetLanguage + "&tk=",
+            "https://translate.googleapis.com/translate_a/t?anno=3&client=te&v=1.0&format=html&sl=auto&tl=" + targetLanguage + "&tk=",
             sourceArray,
             requestBody,
             "q",


### PR DESCRIPTION
translate.googleapis.com  is very well in Chinese Mainland.    <1s  ( see: http://www.17ce.com/site/http/20210307_f451e6d07f0e11eba7135ba6f70ad643:1.html

Actually, `translate.googleapis.cn`  is broken  in commit 774b45c , you can reproduce if visit it.

I've done the test.