### PR TITLE
fix: do not sort the google translate results

### DIFF
--- a/background/translationService.js
+++ b/background/translationService.js
@@ -228,7 +228,7 @@ var translationService = {}
                     http.open("POST", translationServiceURL + tk)
                     http.setRequestHeader("Content-Type", "application/x-www-form-urlencoded")
                     http.responseType = "json"
-                    http.send(requests[idx].requestBody) 
+                    http.send(requests[idx].requestBody)
                 } else {
                     http.open("GET", translationServiceURL + requests[idx].requestBody)
                     http.setRequestHeader("Content-Type", "application/x-www-form-urlencoded")
@@ -435,33 +435,23 @@ var translationService = {}
                     }
 
                     result = sentences.length > 0 ? sentences.join(" ") : result
+                    // Should not sort the <a i={number}> of Google Translate result
+                    // Instead of it, join the texts without sorting
+                    // https://github.com/FilipePS/Traduzir-paginas-web/issues/163
                     let resultArray = result.match(/\<a\si\=[0-9]+\>[^\<\>]*(?=\<\/a\>)/g)
 
-                    let indexes
                     if (resultArray && resultArray.length > 0) {
-                        indexes = resultArray.map(value => parseInt(value.match(/[0-9]+(?=\>)/g))).filter(value => !isNaN(value))
                         resultArray = resultArray.map(value => {
                             var resultStartAtIndex = value.indexOf('>')
                             return value.slice(resultStartAtIndex + 1)
                         })
                     } else {
                         resultArray = [result]
-                        indexes = [0]
                     }
 
                     resultArray = resultArray.map(value => value.replace(/\<\/b\>/g, ""))
                     resultArray = resultArray.map(value => unescapeHTML(value))
-
-                    const finalResulArray = []
-                    for (const j in indexes) {
-                        if (finalResulArray[indexes[j]]) {
-                            finalResulArray[indexes[j]] += " " + resultArray[j]
-                        } else {
-                            finalResulArray[indexes[j]] = resultArray[j]
-                        }
-                    }
-
-                    resultArray3d.push(finalResulArray)
+                    resultArray3d.push(resultArray)
                 }
 
                 //return fixResultArray(resultArray3d, fixIndexesMap)

--- a/contentScript/pageTranslator.js
+++ b/contentScript/pageTranslator.js
@@ -45,7 +45,7 @@ twpConfig.onReady(function() {
     const htmlTagsInlineText = ['#text', 'A', 'ABBR', 'ACRONYM', 'B', 'BDO', 'BIG', 'CITE', 'DFN', 'EM', 'I', 'LABEL', 'Q', 'S', 'SMALL', 'SPAN', 'STRONG', 'SUB', 'SUP', 'U', 'TT', 'VAR']
     const htmlTagsInlineIgnore = ['BR', 'CODE', 'KBD', 'WBR'] // and input if type is submit or button, and pre depending on settings
     const htmlTagsNoTranslate = ['TITLE', 'SCRIPT', 'STYLE', 'TEXTAREA']
-
+    
     if (twpConfig.get('translateTag_pre') !== 'yes') {
         htmlTagsInlineIgnore.push('PRE')
     }
@@ -62,12 +62,12 @@ twpConfig.onReady(function() {
                 break
         }
     })
-
+    
     //TODO FOO
     if (twpConfig.get("useOldPopup") == "yes" || twpConfig.get("popupPanelSection") <= 1) {
         twpConfig.set("targetLanguage", twpConfig.get("targetLanguages")[0])
     }
-
+    
     let nodesToTranslate = []
     let originalPageLanguage = "und"
     let currentPageLanguage = "und"
@@ -75,34 +75,34 @@ twpConfig.onReady(function() {
     let currentTargetLanguage = twpConfig.get("targetLanguage")
     let currentPageTranslatorService = twpConfig.get("pageTranslatorService")
     let fooCount = 0
-
+    
     let originalPageTitle
-
+    
     let attributesToTranslate = []
-
+    
     let translateNewNodesTimerHandler
     let newNodes = []
     let removedNodes = []
-
+    
     let nodesToRestore = []
-
+    
     function translateNewNodes() {
         try {
             newNodes.forEach(nn => {
                 if (removedNodes.indexOf(nn) != -1) return;
                 
                 let newNodesToTranslate = getNodesToTranslate(nn)
-    
+                
                 for (const i in newNodesToTranslate) {
                     const newNodesInfo = newNodesToTranslate[i].nodesInfo
                     let finded = false
-
+                    
                     for (const ntt of nodesToTranslate) {
                         if (ntt.nodesInfo.some(v1 => newNodesInfo.some(v2 => v1.node === v2.node))) {
                             finded = true
                         }
                     }
-
+                    
                     if (!finded) {
                         showOriginal.add(newNodesToTranslate[i].parent)
                         nodesToTranslate.push(newNodesToTranslate[i])
@@ -116,8 +116,8 @@ twpConfig.onReady(function() {
             removedNodes = []
         }
     }
-
-    const mutationObserver = new MutationObserver(function(mutations) {
+    
+    const mutationObserver = new MutationObserver(function (mutations) {
         const nodesToTranslate = []
         
         mutations.forEach(mutation => {
@@ -125,12 +125,12 @@ twpConfig.onReady(function() {
                 if (htmlTagsNoTranslate.indexOf(addedNode.nodeName) == -1) {
                     if (htmlTagsInlineText.indexOf(addedNode.nodeName) == -1) {
                         if (htmlTagsInlineIgnore.indexOf(addedNode.nodeName) == -1) {
-                            nodesToTranslate.push(addedNode) 
+                            nodesToTranslate.push(addedNode)
                         }
                     }
                 }
             })
-
+            
             mutation.removedNodes.forEach(removedNode => {
                 removedNodes.push(removedNode)
             })
@@ -142,13 +142,13 @@ twpConfig.onReady(function() {
             }
         })
     })
-
+    
     function enableMutatinObserver() {
         disableMutatinObserver()
         translateNewNodesTimerHandler = setInterval(translateNewNodes, 2000)
         mutationObserver.observe(document.body, { childList: true, subtree: true })
     }
-
+    
     function disableMutatinObserver() {
         clearInterval(translateNewNodesTimerHandler)
         newNodes = []
@@ -156,7 +156,7 @@ twpConfig.onReady(function() {
         mutationObserver.disconnect()
         mutationObserver.takeRecords()
     }
-
+    
     const handleVisibilityChange = function () {
         if (document.visibilityState == "visible" && pageLanguageState === "translated") {
             enableMutatinObserver()
@@ -165,43 +165,45 @@ twpConfig.onReady(function() {
         }
     }
     document.addEventListener("visibilitychange", handleVisibilityChange, false)
-
-    function getNodesToTranslate(root=document.body) {
-        const nodesToTranslate = [{isTranslated: false, parent: null, nodesInfo: []}]
+    
+    function getNodesToTranslate(root = document.body) {
+        const nodesToTranslate = [{ isTranslated: false, parent: null, nodesInfo: [] }]
         let index = 0
         
         const getAllNodes = function (element) {
             if (element.nodeType == 1 || element.nodeType == 11) {
                 if (element.nodeType == 1) {
                     if (htmlTagsInlineIgnore.indexOf(element.nodeName) !== -1
-                    || htmlTagsNoTranslate.indexOf(element.nodeName) !== -1
-                    || element.classList.contains("notranslate")
-                    || element.getAttribute("translate") === "no"
-                    || element.isContentEditable) {
+                        || htmlTagsNoTranslate.indexOf(element.nodeName) !== -1
+                        || element.classList.contains("notranslate")
+                        || element.getAttribute("translate") === "no"
+                        || element.isContentEditable) {
                         if (nodesToTranslate[index].nodesInfo.length > 0) {
-                            nodesToTranslate.push({isTranslated: false, parent: null, nodesInfo: []})
+                            nodesToTranslate.push({ isTranslated: false, parent: null, nodesInfo: [] })
                             index++
                         }
                         return
                     }
                 }
+                
                 function getAllChilds(childNodes) {
                     Array.from(childNodes).forEach(value => {
                         if (htmlTagsInlineText.indexOf(value.nodeName) == -1) {
                             if (nodesToTranslate[index].nodesInfo.length > 0) {
-                                nodesToTranslate.push({isTranslated: false, parent: null, nodesInfo: []})
-                                index++ 
+                                nodesToTranslate.push({ isTranslated: false, parent: null, nodesInfo: [] })
+                                index++
                             }
                             getAllNodes(value)
                             if (nodesToTranslate[index].nodesInfo.length > 0) {
-                                nodesToTranslate.push({isTranslated: false, parent: null, nodesInfo: []})
-                                index++ 
+                                nodesToTranslate.push({ isTranslated: false, parent: null, nodesInfo: [] })
+                                index++
                             }
                         } else {
                             getAllNodes(value)
                         }
                     })
                 }
+                
                 getAllChilds(element.childNodes)
                 if (element.shadowRoot) {
                     getAllChilds(element.shadowRoot.childNodes)
@@ -223,31 +225,31 @@ twpConfig.onReady(function() {
             }
         }
         getAllNodes(root)
-
+        
         if (nodesToTranslate.length > 0 && nodesToTranslate[nodesToTranslate.length-1].nodesInfo.length == 0) {
             nodesToTranslate.pop()
         }
         
         return nodesToTranslate
     }
-
-    function getAttributesToTranslate(root=document.body) {
+    
+    function getAttributesToTranslate(root = document.body) {
         const attributesToTranslate = []
-
+        
         const placeholdersElements = root.querySelectorAll('input[placeholder], textarea[placeholder]')
         const altElements = root.querySelectorAll('area[alt], img[alt], input[type="image"][alt]')
         const valueElements = root.querySelectorAll('input[type="button"], input[type="submit"]')
         const titleElements = root.querySelectorAll("body [title]")
-
+        
         function hasNoTranslate(elem) {
             if (elem && (elem.classList.contains("notranslate") || elem.getAttribute("translate") === "no")) {
                 return true
             }
         }
-
+        
         placeholdersElements.forEach(e => {
             if (hasNoTranslate(e)) return;
-
+            
             const txt = e.getAttribute("placeholder")
             if (txt && txt.trim()) {
                 attributesToTranslate.push({
@@ -257,10 +259,10 @@ twpConfig.onReady(function() {
                 })
             }
         })
-
+        
         altElements.forEach(e => {
             if (hasNoTranslate(e)) return;
-
+            
             const txt = e.getAttribute("alt")
             if (txt && txt.trim()) {
                 attributesToTranslate.push({
@@ -270,7 +272,7 @@ twpConfig.onReady(function() {
                 })
             }
         })
-
+        
         valueElements.forEach(e => {
             if (hasNoTranslate(e)) return;
             
@@ -289,7 +291,7 @@ twpConfig.onReady(function() {
                 })
             }
         })
-
+        
         titleElements.forEach(e => {
             if (hasNoTranslate(e)) return;
             
@@ -302,37 +304,42 @@ twpConfig.onReady(function() {
                 })
             }
         })
-
+        
         return attributesToTranslate
     }
-
+    
     function translateResults(nodesToTranslatesNow, results) {
-        for (const i in nodesToTranslatesNow) {
-            for (const j in nodesToTranslatesNow[i]) {
-                if (results[i][j]) {
+        for (let i = 0; i < results.length; i++) {
+            for (let j = 0; j < results[i].length; j++) {
+                if (nodesToTranslatesNow[i][j]) {
                     const nodeInfo = nodesToTranslatesNow[i][j]
-                    nodesToRestore.push({node: nodeInfo.node, original: nodeInfo.node.textContent})
+                    nodesToRestore.push({ node: nodeInfo.node, original: nodeInfo.node.textContent })
                     nodeInfo.node.textContent = results[i][j] + " "
+                    // In some case, results items count is over original node count
+                    // Rest results append to last node
+                    if (nodesToTranslatesNow[i].length - 1 === j && results[i].length > j) {
+                        const restResults = results[i].slice(j + 1);
+                        nodeInfo.node.textContent += restResults.join(" ");
+                    }
                 }
             }
         }
-
         mutationObserver.takeRecords()
     }
-
+    
     function translateAttributes(attributesToTranslateNow, results) {
         for (const i in attributesToTranslateNow) {
             const ati = attributesToTranslateNow[i]
             ati.node.setAttribute(ati.attrName, results[i])
         }
     }
-
+    
     function translateDynamically() {
         try {
             if (nodesToTranslate) {
                 ;(function () {
                     const currentFooCount = fooCount
-
+                    
                     const nodesToTranslatesNow = []
                     nodesToTranslate.forEach(nti => {
                         if (!nti.isTranslated) {
@@ -343,7 +350,7 @@ twpConfig.onReady(function() {
                             }
                         }
                     })
-
+                    
                     const attributesToTranslateNow = []
                     attributesToTranslate.forEach(ati => {
                         if (!ati.isTranslated) {
@@ -354,31 +361,31 @@ twpConfig.onReady(function() {
                             }
                         }
                     })
-
+                    
                     if (nodesToTranslatesNow.length > 0) {
                         backgroundTranslateHTML(
                             currentPageTranslatorService,
                             currentTargetLanguage,
                             nodesToTranslatesNow.map(nti => nti.map(value => value.original))
                         )
-                        .then(results => {
-                            if (pageLanguageState === "translated" && currentFooCount === fooCount) {
-                                translateResults(nodesToTranslatesNow, results)
-                            }
-                        })
+                            .then(results => {
+                                if (pageLanguageState === "translated" && currentFooCount === fooCount) {
+                                    translateResults(nodesToTranslatesNow, results)
+                                }
+                            })
                     }
-
+                    
                     if (attributesToTranslateNow.length > 0) {
                         backgroundTranslateText(
                             currentPageTranslatorService,
                             currentTargetLanguage,
                             attributesToTranslateNow.map(ati => ati.original)
                         )
-                        .then(results => {
-                            if (pageLanguageState === "translated" && currentFooCount === fooCount) {
-                                translateAttributes(attributesToTranslateNow, results)
-                            }
-                        })
+                            .then(results => {
+                                if (pageLanguageState === "translated" && currentFooCount === fooCount) {
+                                    translateAttributes(attributesToTranslateNow, results)
+                                }
+                            })
                     }
                 })()
             }
@@ -387,8 +394,9 @@ twpConfig.onReady(function() {
         }
         setTimeout(translateDynamically, 600)
     }
+    
     translateDynamically()
-
+    
     function translatePageTitle() {
         const title = document.querySelector("title");
         if (title && (
@@ -399,68 +407,68 @@ twpConfig.onReady(function() {
         }
         if (document.title.trim().length < 1) return;
         originalPageTitle = document.title
-
+        
         backgroundTranslateSingleText(currentPageTranslatorService, currentTargetLanguage, originalPageTitle)
-        .then(result => {
-            if (result) {
-                document.title = result
-            }
-        })
+            .then(result => {
+                if (result) {
+                    document.title = result
+                }
+            })
     }
-
+    
     const pageLanguageStateObservers = []
-
+    
     pageTranslator.onPageLanguageStateChange = function (callback) {
         pageLanguageStateObservers.push(callback)
     }
-
+    
     pageTranslator.translatePage = function (targetLanguage) {
         fooCount++
         pageTranslator.restorePage()
         showOriginal.enable()
-
+        
         if (targetLanguage) {
             currentTargetLanguage = targetLanguage
         }
-
+        
         nodesToTranslate = getNodesToTranslate()
         attributesToTranslate = getAttributesToTranslate()
-
+        
         nodesToTranslate.forEach(nti => showOriginal.add(nti.parent))
-
+        
         pageLanguageState = "translated"
-        chrome.runtime.sendMessage({action: "setPageLanguageState", pageLanguageState})
+        chrome.runtime.sendMessage({ action: "setPageLanguageState", pageLanguageState })
         pageLanguageStateObservers.forEach(callback => callback(pageLanguageState))
         currentPageLanguage = currentTargetLanguage
-
+        
         translatePageTitle()
-
+        
         enableMutatinObserver()
     }
-
+    
     pageTranslator.restorePage = function () {
         fooCount++
         nodesToTranslate = []
         
         showOriginal.disable()
         disableMutatinObserver()
-
+        
         pageLanguageState = "original"
         chrome.runtime.sendMessage({action: "setPageLanguageState", pageLanguageState})
         pageLanguageStateObservers.forEach(callback => callback(pageLanguageState))
         currentPageLanguage = originalPageLanguage
-
+        
         if (originalPageTitle) {
             document.title = originalPageTitle
         }
         originalPageTitle = null
-
-
+        
+        
         for (const ntr of nodesToRestore) {
             ntr.node.textContent = ntr.original
         }
         nodesToRestore = []
-
+        
         for (const ati of attributesToTranslate) {
             if (ati.isTranslated) {
                 ati.node.setAttribute(ati.attrName, ati.original)
@@ -468,7 +476,7 @@ twpConfig.onReady(function() {
         }
         attributesToTranslate = []
     }
-
+    
     pageTranslator.swapTranslationService = function () {
         if (currentPageTranslatorService === "google") {
             currentPageTranslatorService = "yandex"
@@ -479,7 +487,7 @@ twpConfig.onReady(function() {
             pageTranslator.translatePage()
         }
     }
-
+    
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         if (request.action === "translatePage") {
             if (request.targetLanguage === "original") {
@@ -507,10 +515,10 @@ twpConfig.onReady(function() {
             }
         }
     })
-
+    
     let alreadyGotTheLanguage = false
     const observers = []
-
+    
     pageTranslator.onGetOriginalPageLanguage = function (callback) {
         if (alreadyGotTheLanguage) {
             callback(originalPageLanguage)
@@ -518,7 +526,7 @@ twpConfig.onReady(function() {
             observers.push(callback)
         }
     }
-
+    
     const detectPageLanguage = function () {
         if (chrome.i18n.detectLanguage) {
             chrome.i18n.detectLanguage(document.body.innerText, result => {
@@ -541,7 +549,7 @@ twpConfig.onReady(function() {
                         break
                     }
                 }
-    
+                
                 observers.forEach(callback => callback(originalPageLanguage))
                 alreadyGotTheLanguage = true
             })
@@ -555,7 +563,7 @@ twpConfig.onReady(function() {
             alreadyGotTheLanguage = true
         }
     }
-
+    
     setTimeout(function () {
         if (document.visibilityState == "visible") {
             detectPageLanguage()
@@ -569,7 +577,7 @@ twpConfig.onReady(function() {
             document.addEventListener("visibilitychange", handleVisibilityChange, false)
         }
     }, 100)
-
+    
     pageTranslator.onGetOriginalPageLanguage(function () {
         chrome.runtime.sendMessage({action: "getMainFramePageLanguageState"}, response => {
             if (response === "translated" && pageLanguageState === "original") {


### PR DESCRIPTION
Fix unnatural translation order when the text is wrapped tag like `<b>` or `<a>`

## Pros

- Fix unnatural order in some language

## Cons

- This PR insert may translated text to a different node from the original node 
   - Google Translate copy the style from the original node
   - This PR append rest results to the last node

```
Request:
<a i=0>TranslateWebPages is created by </a><a i=1><b>FilipePS</b></a>
Response:
<a i=1>TranslateWebPagesはFilipePS</a><a i=0>によって作成され</a><a i=1>ます</a>
```

Google translation result:

`<a i=1>` will be `<b>` because original node style is `<b>`

```
<b>TranslateWebPagesはFilipePS</b>によって作成され<b>ます</b>
```

This PR result:

The original text has 2 `<a i=x>`, but the translated result has 3 `<a i=x>`.

```
TranslateWebPagesはFilipePS<b>によって作成されます</b>

TranslateWebPagesはFilipePS | <b>[によって作成され, ます].join(" ")</b>
```

I felt that both are unnatural, I have no opinion.

fix https://github.com/FilipePS/Traduzir-paginas-web/issues/163
