### PR TITLE
Revamp translate text popup

### DIFF
--- a/contentScript/css/translateSelected.css
+++ b/contentScript/css/translateSelected.css
@@ -69,7 +69,6 @@ li {
     padding: 4px 6px;
     border-radius: 5px;
     box-shadow: 0 0 3px -2px black;
-    background-color: rgba(0, 0, 0, 0.4);
     border: none;
     transition: 0.2s;
 }
@@ -85,7 +84,6 @@ li:hover {
     padding: 4px 6px;
     border-radius: 5px;
     box-shadow: 0 0 3px -2px black;
-    background-color: rgba(0, 0, 0, 0.4);
     max-height: 16px;
     border: none;
     transition: 0.2s;
@@ -97,11 +95,9 @@ li:hover {
 
 hr {
     width: 90%;
-    border: 1px black solid;
 }
 
 .selected {
-    background-color: rgba(0, 0, 0, 0.6);
     border: none;
 }
 

--- a/contentScript/css/translateSelected.css
+++ b/contentScript/css/translateSelected.css
@@ -1,5 +1,5 @@
 * {
-    scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0);
+    scrollbar-color: rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.2);
 }
 
 #eDivResult {
@@ -46,7 +46,6 @@
     all: initial;
     z-index: 2147483647;
     position: fixed;
-    background-repeat: no-repeat;
     background-size: cover;
     background-image: url("/icons/icon-32.png");
     width: 22px;
@@ -103,7 +102,7 @@ li:hover {
 }
 
 hr {
-    width: 90%;
+    width: 95%;
 }
 
 .selected {

--- a/contentScript/css/translateSelected.css
+++ b/contentScript/css/translateSelected.css
@@ -1,23 +1,24 @@
+* {
+    scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0);
+}
+
 #eDivResult {
     all: initial;
-    font-family: 'Helvetica', 'Arial', sans-serif;
+    font-family: Arial, sans-serif;
     font-style: normal;
     font-variant: normal;
     line-height: normal;
     font-size: 12px;
     font-weight: 500;
-
-    z-index: 2147483647;
     position: fixed;
-    border-radius: 5px;
-    top: 0px;
-    left: 0px;
-    background-color: white;
-    color: black;
-    border: 1px solid grey;
+    border-radius: 10px;
+    top: 0;
+    left: 0;
+    color: white;
     visibility: visible;
     opacity: 1;
     display: none;
+    z-index: 2;
 }
 
 #eSelTextTrans,
@@ -43,8 +44,8 @@
     background-image: url("/icons/icon-32.png");
     width: 22px;
     height: 22px;
-    top: 0px;
-    left: 0px;
+    top: 0;
+    left: 0;
     cursor: pointer;
     visibility: visible;
     opacity: 1;
@@ -52,7 +53,7 @@
 }
 
 ul {
-    margin: 0px;
+    margin: 0;
     padding: 3px;
     list-style-type: none;
     overflow: hidden;
@@ -60,17 +61,21 @@ ul {
 }
 
 li {
-    margin: 3px;
+    margin: 5px;
     float: left;
     cursor: pointer;
     text-align: center;
+    vertical-align: middle;
     padding: 4px 6px;
-    border-radius: 6px;
-    box-shadow: 0 0 2px 0px #999;
+    border-radius: 5px;
+    box-shadow: 0 0 3px -2px black;
+    background-color: rgba(0, 0, 0, 0.4);
+    border: none;
+    transition: 0.2s;
 }
 
 li:hover {
-    background-color: #ccc;
+    transform: translateY(-1px);
 }
 
 #moreOrLess {
@@ -78,25 +83,30 @@ li:hover {
     cursor: pointer;
     text-align: center;
     padding: 4px 6px;
-    border-radius: 6px;
-    box-shadow: 0 0 2px 0px #999;
+    border-radius: 5px;
+    box-shadow: 0 0 3px -2px black;
+    background-color: rgba(0, 0, 0, 0.4);
     max-height: 16px;
+    border: none;
+    transition: 0.2s;
 }
 
 #moreOrLess:hover {
-    background-color: #ccc;
+    transform: translateY(-1px);
 }
 
 hr {
-    border: 1px solid #ddd;
+    width: 90%;
+    border: 1px black solid;
 }
 
 .selected {
-    background-color: #ccc;
+    background-color: rgba(0, 0, 0, 0.6);
+    border: none;
 }
 
 .arrow {
-    border: solid black;
+    border: solid white;
     border-width: 0 1px 1px 0;
     display: inline-block;
     padding: 3px;
@@ -132,8 +142,4 @@ hr {
 #listen {
     padding-top: 6px;
     padding-bottom: 2px;
-}
-
-#listen svg {
-    enable-background: new 0 0 93.038 93.038;
 }

--- a/contentScript/css/translateSelected.css
+++ b/contentScript/css/translateSelected.css
@@ -26,13 +26,20 @@
     padding: 14px;
     font-size: 16px;
     max-width: 360px;
-    max-height: 260px;
+    max-height: 250px;
     overflow: auto;
     white-space: pre-wrap;
+    min-height: 25px;
 }
 
 #eOrigText {
     outline: none;
+    max-width: 240px;
+}
+
+#eSelTextTrans {
+    float: left;
+    width: 200px;
 }
 
 #eButtonTransSelText {
@@ -61,8 +68,8 @@ ul {
 }
 
 li {
-    margin: 5px;
     float: left;
+    margin: 5px;
     cursor: pointer;
     text-align: center;
     vertical-align: middle;
@@ -72,6 +79,8 @@ li {
     border: none;
     transition: 0.2s;
 }
+
+
 
 li:hover {
     transform: translateY(-1px);
@@ -121,6 +130,7 @@ hr {
 }
 
 #drag {
+    width: 275px;
     display: flex;
     justify-content: space-between;
     flex-direction: row;

--- a/contentScript/translateSelected.js
+++ b/contentScript/translateSelected.js
@@ -5,144 +5,141 @@
 var translateSelected = {}
 
 function getTabHostName() {
-    return new Promise(resolve => chrome.runtime.sendMessage({action: "getTabHostName"}, result => resolve(result)))
+	return new Promise(resolve => chrome.runtime.sendMessage({action: "getTabHostName"}, result => resolve(result)))
 }
 
-Promise.all([twpConfig.onReady(), getTabHostName()])
-.then(function (_) {
-    const tabHostName = _[1]
-    let styleTextContent = ""
-    fetch(chrome.runtime.getURL("/contentScript/css/translateSelected.css"))
-        .then(response => response.text())
-        .then(response => {
-            styleTextContent = response.replace('/icons/icon-32.png', chrome.runtime.getURL("/icons/icon-32.png"))
-        })
-        .catch(e => console.error(e))
-
-    let divElement
-    let eButtonTransSelText
-    let eDivResult
-    let eSelTextTrans
-    let eOrigText
-    let eOrigTextDiv
-
-    let originalTabLanguage = "und"
-    let currentTargetLanguages = twpConfig.get("targetLanguages")
-    let currentTargetLanguage = twpConfig.get("targetLanguageTextTranslation")
-    let currentTextTranslatorService = twpConfig.get("textTranslatorService")
-    let awaysTranslateThisSite = twpConfig.get("alwaysTranslateSites").indexOf(tabHostName) !== -1
-    let translateThisSite = twpConfig.get("neverTranslateSites").indexOf(tabHostName) === -1
-    let translateThisLanguage = twpConfig.get("neverTranslateLangs").indexOf(originalTabLanguage) === -1
-    let showTranslateSelectedButton = twpConfig.get("showTranslateSelectedButton")
-    let dontShowIfPageLangIsTargetLang = twpConfig.get("dontShowIfPageLangIsTargetLang")
-    let dontShowIfPageLangIsUnknown = twpConfig.get("dontShowIfPageLangIsUnknown")
-    let dontShowIfSelectedTextIsTargetLang = twpConfig.get("dontShowIfSelectedTextIsTargetLang")
-    let dontShowIfSelectedTextIsUnknown = twpConfig.get("dontShowIfSelectedTextIsUnknown")
-    let fooCount = 0
-
-    pageTranslator.onGetOriginalTabLanguage(function (tabLanguage) {
-        originalTabLanguage = tabLanguage
-        translateThisLanguage = twpConfig.get("neverTranslateLangs").indexOf(originalTabLanguage) === -1
-        updateEventListener()
-    })
-
-    async function detectTextLanguage(text) {
-        if (!chrome.i18n.detectLanguage) return "und"
-
-        return await new Promise(resolve => {
-            chrome.i18n.detectLanguage(text, result => {
-                if (!result) return resolve("und")
-
-                for (const langInfo of result.languages) {
-                    const langCode = twpLang.checkLanguageCode(langInfo.language)
-                    if (langCode) {
-                        return resolve(langCode)
-                    }
-                }
-
-                return resolve("und")
-            })
-        })
-    }
-
-    let audioDataUrls = null
-    let isPlayingAudio = false
-
-    function stopAudio() {
-        if (isPlayingAudio) {
-            chrome.runtime.sendMessage({
-                action: "stopAudio"
-            })
-        }
-        isPlayingAudio = false
-    }
-
-    function dragElement(elmnt, elmnt2) {
-        var pos1 = 0,
-            pos2 = 0,
-            pos3 = 0,
-            pos4 = 0;
-        if (elmnt2) {
-            elmnt2.addEventListener("mousedown", dragMouseDown);
-        } else {
-            elmnt.addEventListener("mousedown", dragMouseDown);
-        }
-
-        function dragMouseDown(e) {
-            e = e || window.event;
-            e.preventDefault();
-            // get the mouse cursor position at startup:
-            pos3 = e.clientX;
-            pos4 = e.clientY;
-            document.addEventListener("mouseup", closeDragElement);
-            // call a function whenever the cursor moves:
-            document.addEventListener("mousemove", elementDrag);
-        }
-
-        function elementDrag(e) {
-            e = e || window.event;
-            e.preventDefault();
-            // calculate the new cursor position:
-            pos1 = pos3 - e.clientX;
-            pos2 = pos4 - e.clientY;
-            pos3 = e.clientX;
-            pos4 = e.clientY;
-            // set the element's new position:
-            elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
-            elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
-        }
-
-        function closeDragElement() {
-            // stop moving when mouse button is released:
-            document.removeEventListener("mouseup", closeDragElement);
-            document.removeEventListener("mousemove", elementDrag);
-        }
-    }
-
-    function setCaretAtEnd() {
-        const el = eOrigText
-        const range = document.createRange()
-        const sel = window.getSelection()
-        range.setStart(el, 1)
-        range.collapse(true)
-        sel.removeAllRanges()
-        sel.addRange(range)
-        el.focus()
-    }
-
-    function init() {
-        destroy()
-
-        window.isTranslatingSelected = true
-
-        divElement = document.createElement("div")
-        divElement.style = "all: initial"
-        divElement.classList.add("notranslate")
-
-        const shadowRoot = divElement.attachShadow({
-            mode: "closed"
-        })
-        shadowRoot.innerHTML = `
+Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
+	const tabHostName = _[1]
+	let styleTextContent = ""
+	fetch(chrome.runtime.getURL("/contentScript/css/translateSelected.css")).then(response => response.text()).then(response => {
+		styleTextContent = response.replace('/icons/icon-32.png', chrome.runtime.getURL("/icons/icon-32.png"))
+	}).catch(e => console.error(e))
+	
+	let divElement
+	let eButtonTransSelText
+	let eDivResult
+	let eSelTextTrans
+	let eOrigText
+	let eOrigTextDiv
+	
+	let originalTabLanguage = "und"
+	let currentTargetLanguages = twpConfig.get("targetLanguages")
+	let currentTargetLanguage = twpConfig.get("targetLanguageTextTranslation")
+	let currentTextTranslatorService = twpConfig.get("textTranslatorService")
+	let awaysTranslateThisSite = twpConfig.get("alwaysTranslateSites").indexOf(tabHostName) !== -1
+	let translateThisSite = twpConfig.get("neverTranslateSites").indexOf(tabHostName) === -1
+	let translateThisLanguage = twpConfig.get("neverTranslateLangs").indexOf(originalTabLanguage) === -1
+	let showTranslateSelectedButton = twpConfig.get("showTranslateSelectedButton")
+	let dontShowIfPageLangIsTargetLang = twpConfig.get("dontShowIfPageLangIsTargetLang")
+	let dontShowIfPageLangIsUnknown = twpConfig.get("dontShowIfPageLangIsUnknown")
+	let dontShowIfSelectedTextIsTargetLang = twpConfig.get("dontShowIfSelectedTextIsTargetLang")
+	let dontShowIfSelectedTextIsUnknown = twpConfig.get("dontShowIfSelectedTextIsUnknown")
+	let fooCount = 0
+	
+	pageTranslator.onGetOriginalTabLanguage(function (tabLanguage) {
+		originalTabLanguage = tabLanguage
+		translateThisLanguage = twpConfig.get("neverTranslateLangs").indexOf(originalTabLanguage) === -1
+		updateEventListener()
+	})
+	
+	async function detectTextLanguage(text) {
+		if (!chrome.i18n.detectLanguage) return "und"
+		
+		return await new Promise(resolve => {
+			chrome.i18n.detectLanguage(text, result => {
+				if (!result) return resolve("und")
+				
+				for (const langInfo of result.languages) {
+					const langCode = twpLang.checkLanguageCode(langInfo.language)
+					if (langCode) {
+						return resolve(langCode)
+					}
+				}
+				
+				return resolve("und")
+			})
+		})
+	}
+	
+	let audioDataUrls = null
+	let isPlayingAudio = false
+	
+	function stopAudio() {
+		if (isPlayingAudio) {
+			chrome.runtime.sendMessage({
+				action: "stopAudio"
+			})
+		}
+		isPlayingAudio = false
+	}
+	
+	function dragElement(elmnt, elmnt2) {
+		var pos1 = 0,
+			pos2 = 0,
+			pos3 = 0,
+			pos4 = 0;
+		if (elmnt2) {
+			elmnt2.addEventListener("mousedown", dragMouseDown);
+		} else {
+			elmnt.addEventListener("mousedown", dragMouseDown);
+		}
+		
+		function dragMouseDown(e) {
+			e = e || window.event;
+			e.preventDefault();
+			// get the mouse cursor position at startup:
+			pos3 = e.clientX;
+			pos4 = e.clientY;
+			document.addEventListener("mouseup", closeDragElement);
+			// call a function whenever the cursor moves:
+			document.addEventListener("mousemove", elementDrag);
+		}
+		
+		function elementDrag(e) {
+			e = e || window.event;
+			e.preventDefault();
+			// calculate the new cursor position:
+			pos1 = pos3 - e.clientX;
+			pos2 = pos4 - e.clientY;
+			pos3 = e.clientX;
+			pos4 = e.clientY;
+			// set the element's new position:
+			elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
+			elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
+		}
+		
+		function closeDragElement() {
+			// stop moving when mouse button is released:
+			document.removeEventListener("mouseup", closeDragElement);
+			document.removeEventListener("mousemove", elementDrag);
+		}
+	}
+	
+	function setCaretAtEnd() {
+		const el = eOrigText
+		const range = document.createRange()
+		const sel = window.getSelection()
+		range.setStart(el, 1)
+		range.collapse(true)
+		sel.removeAllRanges()
+		sel.addRange(range)
+		el.focus()
+	}
+	
+	function init() {
+		destroy()
+		
+		window.isTranslatingSelected = true
+		
+		divElement = document.createElement("div")
+		divElement.style = "all: initial"
+		divElement.classList.add("notranslate")
+		
+		const shadowRoot = divElement.attachShadow({
+			mode: "closed"
+		})
+		
+		shadowRoot.innerHTML = `
         <link rel="stylesheet" href="${chrome.runtime.getURL("/contentScript/css/translateSelected.css")}">
 
         <div id="eButtonTransSelText"></div>
@@ -152,7 +149,6 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
                     <hr>
                 </div>
                 <div id="eSelTextTrans" dir="auto"></div>
-                <hr>
                 <div id="drag">
                     <ul id="setTargetLanguage">
                         <li value="en" title="English">en</li>
@@ -165,9 +161,17 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
                         <li title="Yandex" id="sYandex">y</li>
                         <li title="Bing" id="sBing">b</li>
                         <li title="DeepL" id="sDeepL" hidden>d</li>
+                        <li title="Copy" data-i18n-title="btnCopy" id="copy">
+                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M13 7H7V5H13V7Z" fill="currentColor" />
+                            <path d="M13 11H7V9H13V11Z" fill="currentColor" />
+                            <path d="M7 15H13V13H7V15Z" fill="currentColor" />
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
+                            </svg>
+                        </li>
                         <li title="Listen" data-i18n-title="btnListen" id="listen">
-                            <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                            width="14px" height="12px" viewBox="0 0 93.038 93.038" xml:space="preserve">
+                            <svg id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                            width="10px" height="10px" viewBox="0 0 93.038 93.038" xml:space="preserve" style="fill: rgb(255, 255, 255)">
                             <g>
                                 <path d="M46.547,75.521c0,1.639-0.947,3.128-2.429,3.823c-0.573,0.271-1.187,0.402-1.797,0.402c-0.966,0-1.923-0.332-2.696-0.973
                                     l-23.098-19.14H4.225C1.892,59.635,0,57.742,0,55.409V38.576c0-2.334,1.892-4.226,4.225-4.226h12.303l23.098-19.14
@@ -181,699 +185,643 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
                                     c-1.479-1.672-1.404-4.203,0.17-5.783l0.554-0.555c0.822-0.826,1.89-1.281,3.115-1.242c1.163,0.033,2.263,0.547,3.036,1.417
                                     c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z"/>
                             </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
-                            <g>
-                            </g>
                             </svg>
                         </li>
                     </ul>
                 </div>
             </div>
         `
-
-        {
-            const style = document.createElement("style")
-            style.textContent = styleTextContent
-            shadowRoot.insertBefore(style, shadowRoot.getElementById("eButtonTransSelText"))
-        }
-
-        dragElement(shadowRoot.getElementById("eDivResult"), shadowRoot.getElementById("drag"))
-
-        function enableDarkMode() {
-            if (!shadowRoot.getElementById("darkModeElement")) {
-                const el = document.createElement("style")
-                el.setAttribute("id", "darkModeElement")
-                el.setAttribute("rel", "stylesheet")
-                el.textContent = `
-                    * {
-                        scrollbar-color: #202324 #454a4d;
-                    }
+        const style = document.createElement("style")
+        style.textContent = styleTextContent
+        shadowRoot.insertBefore(style, shadowRoot.getElementById("eButtonTransSelText"))
+		
+		dragElement(shadowRoot.getElementById("eDivResult"), shadowRoot.getElementById("drag"))
+		
+        if (!CSS.supports("backdrop-filter: blur(5px)")) {
+            const el = document.createElement("style")
+            el.setAttribute("id", "backdropFilterElement")
+            el.setAttribute("rel", "stylesheet")
+            el.textContent = `
                     #eDivResult {
-                        color: rgb(231, 230, 228) !important;
-                        background-color: #181a1b !important;
-                    }
-                    hr {
-                        border-color: #666;
-                    }
-                    li:hover, #moreOrLess:hover {
-                        color: rgb(231, 230, 228) !important;
-                        background-color: #454a4d !important;
-                    }
-                    .selected {
-                        background-color: #454a4d !important;
-                    }
-                    .arrow {
-                        border: solid rgb(231, 230, 228);
-                        border-width: 0 1px 1px 0;
+                        backdrop-filter: none;
+                        background-color: rgba(0, 0, 0, 0.85);
                     }
                 `
-                shadowRoot.appendChild(el)
-                shadowRoot.querySelector("#listen svg").style = "fill: rgb(231, 230, 228)"
-            }
+            shadowRoot.appendChild(el)
+        }else{
+            const el = document.createElement("style")
+            el.setAttribute("id", "backdropFilterElement")
+            el.setAttribute("rel", "stylesheet")
+            el.textContent = `
+                    #eDivResult {
+                        backdrop-filter: blur(3px);
+                        background-color: rgba(0, 0, 0, 0.5);
+                    }
+                `
+            shadowRoot.appendChild(el)
         }
-
-        function disableDarkMode() {
-            if (shadowRoot.getElementById("#darkModeElement")) {
-                shadowRoot.getElementById("#darkModeElement").remove()
-                shadowRoot.querySelector("#listen svg").style = "fill: black"
-            }
-        }
-
-        switch (twpConfig.get("darkMode")) {
-            case "auto":
-                if (matchMedia("(prefers-color-scheme: dark)").matches) {
-                    enableDarkMode()
-                } else {
-                    disableDarkMode()
-                }
-                break
-            case "yes":
-                enableDarkMode()
-                break
-            case "no":
-                disableDarkMode()
-                break
-            default:
-                break
-        }
-
-        eButtonTransSelText = shadowRoot.getElementById("eButtonTransSelText")
-        eDivResult = shadowRoot.getElementById("eDivResult")
-        eSelTextTrans = shadowRoot.getElementById("eSelTextTrans")
-        eOrigText = shadowRoot.getElementById("eOrigText")
-        eOrigTextDiv = shadowRoot.getElementById("eOrigTextDiv")
-
-        const eMoreOrLess = shadowRoot.getElementById("moreOrLess")
-        const eMore = shadowRoot.getElementById("more")
-        const eLess = shadowRoot.getElementById("less")
-
-        const sGoogle = shadowRoot.getElementById("sGoogle")
-        const sYandex = shadowRoot.getElementById("sYandex")
-        const sBing = shadowRoot.getElementById("sBing")
-        const sDeepL = shadowRoot.getElementById("sDeepL")
-
-        eOrigText.onkeypress = e => {
-            e.stopPropagation()
-        }
-
-        eOrigText.onkeydown = e => {
-            e.stopPropagation()
-        }
-
-        let translateNewInputTimerHandler
-        eOrigText.oninput = () => {
-            clearTimeout(translateNewInputTimerHandler)
-            translateNewInputTimerHandler = setTimeout(translateNewInput, 800)
-        }
-
-        eMoreOrLess.onclick = () => {
-            if (twpConfig.get("expandPanelTranslateSelectedText") === "no") {
-                twpConfig.set("expandPanelTranslateSelectedText", "yes")
-            } else {
-                twpConfig.set("expandPanelTranslateSelectedText", "no")
-            }
-
-            setCaretAtEnd()
-        }
-
-        sGoogle.onclick = () => {
-            currentTextTranslatorService = "google"
-            twpConfig.set("textTranslatorService", "google")
-            translateNewInput()
-
-            sGoogle.classList.remove("selected")
-            sYandex.classList.remove("selected")
-            sBing.classList.remove("selected")
-            sDeepL.classList.remove("selected")
-
-            sGoogle.classList.add("selected")
-        }
-        sYandex.onclick = () => {
-            currentTextTranslatorService = "yandex"
-            twpConfig.set("textTranslatorService", "yandex")
-            translateNewInput()
-
-            sGoogle.classList.remove("selected")
-            sYandex.classList.remove("selected")
-            sBing.classList.remove("selected")
-            sDeepL.classList.remove("selected")
-
-            sYandex.classList.add("selected")
-        }
-        sBing.onclick = () => {
-            currentTextTranslatorService = "bing"
-            twpConfig.set("textTranslatorService", "bing")
-            translateNewInput()
-
-            sGoogle.classList.remove("selected")
-            sYandex.classList.remove("selected")
-            sBing.classList.remove("selected")
-            sDeepL.classList.remove("selected")
-
-            sBing.classList.add("selected")
-        }
-        sDeepL.onclick = () => {
-            currentTextTranslatorService = "deepl"
-            twpConfig.set("textTranslatorService", "deepl")
-            translateNewInput()
-
-            sGoogle.classList.remove("selected")
-            sYandex.classList.remove("selected")
-            sBing.classList.remove("selected")
-            sDeepL.classList.remove("selected")
-
-            sDeepL.classList.add("selected")
-        }
-
-        const setTargetLanguage = shadowRoot.getElementById("setTargetLanguage")
-        setTargetLanguage.onclick = e => {
-            if (e.target.getAttribute("value")) {
-                const langCode = twpLang.checkLanguageCode(e.target.getAttribute("value"))
-                if (langCode) {
-                    currentTargetLanguage = langCode
-                    twpConfig.setTargetLanguageTextTranslation(langCode)
-                    translateNewInput()
-                }
-
-                shadowRoot.querySelectorAll("#setTargetLanguage li").forEach(li => {
-                    li.classList.remove("selected")
-                })
-
-                e.target.classList.add("selected")
-            }
-        }
-
+		
+		eButtonTransSelText = shadowRoot.getElementById("eButtonTransSelText")
+		eDivResult = shadowRoot.getElementById("eDivResult")
+		eSelTextTrans = shadowRoot.getElementById("eSelTextTrans")
+		eOrigText = shadowRoot.getElementById("eOrigText")
+		eOrigTextDiv = shadowRoot.getElementById("eOrigTextDiv")
+		
+		const eMoreOrLess = shadowRoot.getElementById("moreOrLess")
+		const eMore = shadowRoot.getElementById("less")
+		const eLess = shadowRoot.getElementById("more")
+		
+		const sGoogle = shadowRoot.getElementById("sGoogle")
+		const sYandex = shadowRoot.getElementById("sYandex")
+		const sBing = shadowRoot.getElementById("sBing")
+		const sDeepL = shadowRoot.getElementById("sDeepL")
+        const eCopy = shadowRoot.getElementById("copy")
         const eListen = shadowRoot.getElementById("listen")
-        eListen.onclick = () => {
-            const msgListen = chrome.i18n.getMessage("btnListen")
-            const msgStopListening = chrome.i18n.getMessage("btnStopListening")
-
-            eListen.classList.remove("selected")
-            eListen.setAttribute("title", msgStopListening)
-
-            if (audioDataUrls) {
-                if (isPlayingAudio) {
-                    stopAudio()
-                    eListen.setAttribute("title", msgListen)
-                } else {
-                    isPlayingAudio = true
-                    chrome.runtime.sendMessage({
-                        action: "playAudio",
-                        audioDataUrls
-                    }, () => {
-                        eListen.classList.remove("selected")
-                        eListen.setAttribute("title", msgListen)
-                    })
-                    eListen.classList.add("selected")
-                }
-            } else {
-                stopAudio()
-                isPlayingAudio = true
-                chrome.runtime.sendMessage({
-                    action: "textToSpeech",
-                    text: eSelTextTrans.textContent,
-                    targetLanguage: currentTargetLanguage
-                }, result => {
-                    if (!result) return;
-
-                    audioDataUrls = result
-                    chrome.runtime.sendMessage({
-                        action: "playAudio",
-                        audioDataUrls
-                    }, () => {
-                        isPlayingAudio = false
-                        eListen.classList.remove("selected")
-                        eListen.setAttribute("title", msgListen)
-                    })
-                })
-                eListen.classList.add("selected")
-            }
-        }
-
-        document.body.appendChild(divElement)
-
-        chrome.i18n.translateDocument(shadowRoot)
-
-        if (platformInfo.isMobile.any) {
-            eButtonTransSelText.style.width = "30px"
-            eButtonTransSelText.style.height = "30px"
-            document.addEventListener("touchstart", onTouchstart)
-        }
-
-        eButtonTransSelText.addEventListener("click", onClick)
-        document.addEventListener("mousedown", onDown)
-
-        const targetLanguageButtons = shadowRoot.querySelectorAll("#setTargetLanguage li")
-
-        for (let i = 0; i < 3; i++) {
-            if (currentTargetLanguages[i] == currentTargetLanguage) {
-                targetLanguageButtons[i].classList.add("selected")
-            }
-            targetLanguageButtons[i].textContent = currentTargetLanguages[i]
-            targetLanguageButtons[i].setAttribute("value", currentTargetLanguages[i])
-            targetLanguageButtons[i].setAttribute("title", twpLang.codeToLanguage(currentTargetLanguages[i]))
-        }
-
-        if (currentTextTranslatorService === "yandex") {
-            sYandex.classList.add("selected")
-        } else if (currentTextTranslatorService == "deepl") {
-            sDeepL.classList.add("selected")
-        } else if (currentTextTranslatorService == "bing") {
-            sBing.classList.add("selected")
-        } else {
-            sGoogle.classList.add("selected")
-        }
-
-        if (twpConfig.get("enableDeepL") === "yes") {
-            sDeepL.removeAttribute("hidden")
-        } else {
-            sDeepL.setAttribute("hidden", "")
-        }
-        if (twpConfig.get("expandPanelTranslateSelectedText") === "yes") {
-            eOrigTextDiv.style.display = "block"
-            eMore.style.display = "none"
-            eLess.style.display = "block"
-            eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("less"))
-        } else {
-            eOrigTextDiv.style.display = "none"
-            eMore.style.display = "block"
-            eLess.style.display = "none"
-            eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("more"))
-        }
-        twpConfig.onChanged((name, newvalue) => {
-            switch (name) {
-                case "enableDeepL":
-                    if (newvalue === "yes") {
-                        sDeepL.removeAttribute("hidden")
-                    } else {
-                        sDeepL.setAttribute("hidden", "")
-                    }
-                    break
-                case "expandPanelTranslateSelectedText":
-                    if (newvalue === "yes") {
-                        eOrigTextDiv.style.display = "block"
-                        eMore.style.display = "none"
-                        eLess.style.display = "block"
-                        eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("less"))
-                    } else {
-                        eOrigTextDiv.style.display = "none"
-                        eMore.style.display = "block"
-                        eLess.style.display = "none"
-                        eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("more"))
-                    }
-                    break
-            }
-        })
-    }
-
-    function destroy() {
-        window.isTranslatingSelected = false
-        fooCount++
-        stopAudio()
-        audioDataUrls = null
-        if (!divElement) return;
-
-        eButtonTransSelText.removeEventListener("click", onClick)
-        document.removeEventListener("mousedown", onDown)
-        if (platformInfo.isMobile.any) {
-            document.removeEventListener("touchstart", onTouchstart)
-        }
-        divElement.remove()
-        divElement = eButtonTransSelText = eDivResult = null
-    }
-
-    function destroyIfButtonIsShowing(e) {
-        if (eButtonTransSelText && e.target !== divElement && eButtonTransSelText.style.display === "block") {
-            destroy()
-        }
-    }
-
-    twpConfig.onChanged(function (name, newValue) {
-        switch (name) {
-            case "textTranslatorService":
-                currentTextTranslatorService = newValue
-                break
-            case "targetLanguages":
-                currentTargetLanguages = newValue
-                break
-            case "targetLanguageTextTranslation":
-                currentTargetLanguage = newValue
-                break
-            case "alwaysTranslateSites":
-                awaysTranslateThisSite = newValue.indexOf(tabHostName) !== -1
-                updateEventListener()
-                break
-            case "neverTranslateSites":
-                translateThisSite = newValue.indexOf(tabHostName) === -1
-                updateEventListener()
-                break
-            case "neverTranslateLangs":
-                translateThisLanguage = newValue.indexOf(originalTabLanguage) === -1
-                updateEventListener()
-                break
-            case "showTranslateSelectedButton":
-                showTranslateSelectedButton = newValue
-                updateEventListener()
-                break
-            case "dontShowIfPageLangIsTargetLang":
-                dontShowIfPageLangIsTargetLang = newValue
-                updateEventListener()
-                break
-            case "dontShowIfPageLangIsUnknown":
-                dontShowIfPageLangIsUnknown = newValue
-                updateEventListener()
-                break
-            case "dontShowIfSelectedTextIsTargetLang":
-                dontShowIfSelectedTextIsTargetLang = newValue
-                break
-            case "dontShowIfSelectedTextIsUnknown":
-                dontShowIfSelectedTextIsUnknown = newValue
-                break
-        }
-    })
-
-    function update_eDivResult(result = "") {
-        if (eDivResult.style.display !== "block") {
-            init()
-        }
-        const eTop = prevSelectionInfo.bottom
-        const eLeft = prevSelectionInfo.left
-
-        if (twpLang.isRtlLanguage(currentTargetLanguage)) {
-            eSelTextTrans.setAttribute("dir", "rtl")
-        } else {
-            eSelTextTrans.setAttribute("dir", "ltr")
-        }
-        eSelTextTrans.textContent = result
-        if (eDivResult.style.display !== "block") {
-            eDivResult.style.display = "block"
-            eDivResult.style.top = "0px"
-            eDivResult.style.left = "0px"
-            eOrigText.textContent = prevSelectionInfo.text
-
-            setCaretAtEnd()
-
-            const height = parseInt(eDivResult.offsetHeight)
-            let top = eTop + 5
-            top = Math.max(0, top)
-            top = Math.min(window.innerHeight - height, top)
-
-            const width = parseInt(eDivResult.offsetWidth)
-            let left = parseInt(eLeft /*- width / 2*/ )
-            left = Math.max(0, left)
-            left = Math.min(window.innerWidth - width, left)
-
-            eDivResult.style.top = top + "px"
-            eDivResult.style.left = left + "px"
-        }
-    }
-
-    function translateNewInput() {
-        fooCount++
-        let currentFooCount = fooCount
-        stopAudio()
-        audioDataUrls = null
-
-        backgroundTranslateSingleText(currentTextTranslatorService, currentTargetLanguage, eOrigText.textContent)
-            .then(result => {
-                if (currentFooCount !== fooCount) return;
-
-                update_eDivResult(result)
+        
+        eCopy.onclick = () => {
+            navigator.clipboard.writeText(eSelTextTrans.textContent).then(() => {
+                eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"
+                setTimeout(() => {
+                    eCopy.style.backgroundColor = "rgba(0, 0, 0, 0.4)"
+                }, 500)
             })
-    }
-
-    let gSelectionInfo
-    let prevSelectionInfo
-
-    function translateSelText(usePrevSelectionInfo = false) {
-        if (!usePrevSelectionInfo && gSelectionInfo) {
-            prevSelectionInfo = gSelectionInfo
-        } else if (!(usePrevSelectionInfo && prevSelectionInfo)) {
-            return
         }
-
-        eOrigText.textContent = prevSelectionInfo.text
-
-        translateNewInput()
-        const currentFooCount = fooCount
-        setTimeout(() => {
-            if (currentFooCount !== fooCount) return;
-            update_eDivResult(eSelTextTrans.textContent)
-            fooCount = currentFooCount
-        }, 1000)
-    }
-
-    function onClick(e) {
-        translateSelText()
-        eButtonTransSelText.style.display = "none"
-    }
-
-    function onDown(e) {
-        if (e.target != divElement) {
-            eDivResult.style.display = "none"
-            eButtonTransSelText.style.display = "none"
-            destroy()
-        }
-    }
-
-
-    let isTouchSelection = false
-
-    function onTouchstart(e) {
-        isTouchSelection = true
-        onDown(e)
-    }
-
-    function getSelectionText() {
-        let text = "";
-        const activeEl = document.activeElement;
-        const activeElTagName = activeEl ? activeEl.tagName.toLowerCase() : null;
-        if (
-            (activeElTagName == "textarea") || (activeElTagName == "input" &&
-                /^(?:text|search)$/i.test(activeEl.type)) &&
-            (typeof activeEl.selectionStart == "number")
-        ) {
-            text = activeEl.value.slice(activeEl.selectionStart, activeEl.selectionEnd);
-        } else if (window.getSelection) {
-            text = window.getSelection().toString();
-        }
-        return text;
-    }
-
-    function readSelection(dontReadIfSelectionDontChange = false) {
-        let newSelectionInfo = null
-
-        const activeEl = document.activeElement;
-        const activeElTagName = activeEl ? activeEl.tagName.toLowerCase() : null;
-        if (
-            (activeElTagName == "textarea") || (activeElTagName == "input" &&
-                /^(?:text|search)$/i.test(activeEl.type)) &&
-            (typeof activeEl.selectionStart == "number")
-        ) {
-            const text = activeEl.value.slice(activeEl.selectionStart, activeEl.selectionEnd);
-            const rect = activeEl.getBoundingClientRect()
-            newSelectionInfo = {
-                text: text,
-                top: rect.top,
-                left: rect.left,
-                bottom: rect.bottom,
-                right: rect.right
-            }
-        } else if (window.getSelection) {
-            const selection = window.getSelection()
-            if (selection.type == "Range") {
-                const text = selection.toString();
-                const rect = selection.getRangeAt(0).getBoundingClientRect()
-                newSelectionInfo = {
-                    text: text,
-                    top: rect.top,
-                    left: rect.left,
-                    bottom: rect.bottom,
-                    right: rect.right
-                }
-            }
-        }
-
-        if (dontReadIfSelectionDontChange && gSelectionInfo && newSelectionInfo && gSelectionInfo.text === newSelectionInfo.text) {
-            gSelectionInfo = newSelectionInfo
-            return false
-        }
-        gSelectionInfo = newSelectionInfo
-        return true
-    }
-
-    async function onUp(e) {
-        if (e.target == divElement) return;
-
-        const clientX = Math.max((typeof e.clientX === 'undefined' ? 0 : e.clientX), (typeof e.changedTouches === 'undefined' ? 0 : e.changedTouches[0].clientX));
-        const clientY = Math.max((typeof e.clientY === 'undefined' ? 0 : e.clientY), (typeof e.changedTouches === 'undefined' ? 0 : e.changedTouches[0].clientY));
-
-        const selectedText = getSelectionText().trim()
-        if (!selectedText || selectedText.length < 1) return;
-        let detectedLanguage = await detectTextLanguage(selectedText)
-        if (!detectedLanguage) detectedLanguage = "und";
-
-        if (((dontShowIfSelectedTextIsTargetLang == "yes" && detectedLanguage !== currentTargetLanguage) || dontShowIfSelectedTextIsTargetLang != "yes") &&
-            ((dontShowIfSelectedTextIsUnknown == "yes" && detectedLanguage !== "und") || dontShowIfSelectedTextIsUnknown != "yes")
-        ) {
-            init()
-            if (platformInfo.isMobile.any) {
-                eButtonTransSelText.style.left = window.innerWidth - 45 + "px"
-                eButtonTransSelText.style.top = clientY + "px"
-            } else {
-                eButtonTransSelText.style.left = clientX + 20 + "px"
-                eButtonTransSelText.style.top = clientY - 30 + "px"
-            }
-
-            eButtonTransSelText.style.display = "block"
-        }
-    }
-
-    let showButtonTimerHandler = null
-
-    function onMouseup(e) {
-        if (e.button != 0) return;
-        if (e.target == divElement) return;
-        if (readSelection(true)) {
-            clearTimeout(showButtonTimerHandler)
-            showButtonTimerHandler = setTimeout(() => onUp(e), 150)
-        }
-    }
-
-    function onTouchend(e) {
-        if (e.target == divElement) return;
-        readSelection()
-        clearTimeout(showButtonTimerHandler)
-        showButtonTimerHandler = setTimeout(() => onUp(e), 150)
-    }
-
-    function onSelectionchange(e) {
-        if (isTouchSelection) {
-            readSelection()
-        }
-    }
-
-    function isSelectingText() {
-        const activeEl = document.activeElement;
-        const activeElTagName = activeEl ? activeEl.tagName.toLowerCase() : null;
-        if (
-            (activeElTagName == "textarea") || (activeElTagName == "input" &&
-                /^(?:text|search)$/i.test(activeEl.type)) &&
-            (typeof activeEl.selectionStart == "number")
-        ) {
-            const text = activeEl.value.slice(activeEl.selectionStart, activeEl.selectionEnd);
-            if (text) return true;
-        } else if (window.getSelection) {
-            const selection = window.getSelection()
-            if (selection.type == "Range") {
-                const text = selection.toString();
-                if (text) return true;
-            }
-        }
-        return false
-    }
-
-    let lastTimePressedCtrl = null
-
-    function onKeyUp(e) {
-        if (twpConfig.get("translateSelectedWhenPressTwice") !== "yes") return;
-        if (e.key == "Control") {
-            if (lastTimePressedCtrl && performance.now() - lastTimePressedCtrl < 280 && isSelectingText()) {
-                lastTimePressedCtrl = performance.now()
-                readSelection()
-                init()
-                translateSelText()
-            }
-            lastTimePressedCtrl = performance.now()
-        }
-    }
-    document.addEventListener("keyup", onKeyUp)
-
-    let windowIsInFocus = true
-    window.addEventListener("focus", function (e) {
-        windowIsInFocus = true
-        chrome.runtime.sendMessage({action: "thisFrameIsInFocus"})
-    })
-    window.addEventListener("blur", function (e) {
-        windowIsInFocus = false
-    })
-
-    window.addEventListener("beforeunload", function (e) {
-        destroy()
-    })
-
-    function updateEventListener() {
-        if (showTranslateSelectedButton == "yes" && (awaysTranslateThisSite || (translateThisSite && translateThisLanguage)) &&
-            ((dontShowIfPageLangIsTargetLang == "yes" && originalTabLanguage !== currentTargetLanguage) || dontShowIfPageLangIsTargetLang != "yes") &&
-            ((dontShowIfPageLangIsUnknown == "yes" && originalTabLanguage !== "und") || dontShowIfPageLangIsUnknown != "yes")
-        ) {
-            document.addEventListener("mouseup", onMouseup)
-
-            document.addEventListener("blur", destroyIfButtonIsShowing)
-            document.addEventListener("visibilitychange", destroyIfButtonIsShowing)
-
-            document.addEventListener("keydown", destroyIfButtonIsShowing)
-            document.addEventListener("mousedown", destroyIfButtonIsShowing)
-            document.addEventListener("wheel", destroyIfButtonIsShowing)
-
-            if (platformInfo.isMobile.any) {
-                document.addEventListener("touchend", onTouchend)
-                document.addEventListener("selectionchange", onSelectionchange)
-            }
-        } else {
-            document.removeEventListener("mouseup", onMouseup)
-
-            document.removeEventListener("blur", destroyIfButtonIsShowing)
-            document.removeEventListener("visibilitychange", destroyIfButtonIsShowing)
-
-            document.removeEventListener("keydown", destroyIfButtonIsShowing)
-            document.removeEventListener("mousedown", destroyIfButtonIsShowing)
-            document.removeEventListener("wheel", destroyIfButtonIsShowing)
-
-            if (platformInfo.isMobile.any) {
-                document.removeEventListener("touchend", onTouchend)
-                document.removeEventListener("selectionchange", onSelectionchange)
-            }
-        }
-    }
-    updateEventListener()
-
-    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-        if (request.action === "TranslateSelectedText") {
-            readSelection()
-            init()
-            translateSelText()
-        } else if (request.action === "anotherFrameIsInFocus")  {
-            if (!windowIsInFocus) {
-                destroy()
-            }
-        }
-    })
+		
+		eOrigText.onkeypress = e => {
+			e.stopPropagation()
+		}
+		
+		eOrigText.onkeydown = e => {
+			e.stopPropagation()
+		}
+		
+		let translateNewInputTimerHandler
+		eOrigText.oninput = () => {
+			clearTimeout(translateNewInputTimerHandler)
+			translateNewInputTimerHandler = setTimeout(translateNewInput, 800)
+		}
+		
+		eMoreOrLess.onclick = () => {
+			if (twpConfig.get("expandPanelTranslateSelectedText") === "no") {
+				twpConfig.set("expandPanelTranslateSelectedText", "yes")
+			} else {
+				twpConfig.set("expandPanelTranslateSelectedText", "no")
+			}
+			
+			setCaretAtEnd()
+		}
+		
+		sGoogle.onclick = () => {
+			currentTextTranslatorService = "google"
+			twpConfig.set("textTranslatorService", "google")
+			translateNewInput()
+			
+			sGoogle.classList.remove("selected")
+			sYandex.classList.remove("selected")
+			sBing.classList.remove("selected")
+			sDeepL.classList.remove("selected")
+			
+			sGoogle.classList.add("selected")
+		}
+		sYandex.onclick = () => {
+			currentTextTranslatorService = "yandex"
+			twpConfig.set("textTranslatorService", "yandex")
+			translateNewInput()
+			
+			sGoogle.classList.remove("selected")
+			sYandex.classList.remove("selected")
+			sBing.classList.remove("selected")
+			sDeepL.classList.remove("selected")
+			
+			sYandex.classList.add("selected")
+		}
+		sBing.onclick = () => {
+			currentTextTranslatorService = "bing"
+			twpConfig.set("textTranslatorService", "bing")
+			translateNewInput()
+			
+			sGoogle.classList.remove("selected")
+			sYandex.classList.remove("selected")
+			sBing.classList.remove("selected")
+			sDeepL.classList.remove("selected")
+			
+			sBing.classList.add("selected")
+		}
+		sDeepL.onclick = () => {
+			currentTextTranslatorService = "deepl"
+			twpConfig.set("textTranslatorService", "deepl")
+			translateNewInput()
+			
+			sGoogle.classList.remove("selected")
+			sYandex.classList.remove("selected")
+			sBing.classList.remove("selected")
+			sDeepL.classList.remove("selected")
+			
+			sDeepL.classList.add("selected")
+		}
+		
+		const setTargetLanguage = shadowRoot.getElementById("setTargetLanguage")
+		setTargetLanguage.onclick = e => {
+			if (e.target.getAttribute("value")) {
+				const langCode = twpLang.checkLanguageCode(e.target.getAttribute("value"))
+				if (langCode) {
+					currentTargetLanguage = langCode
+					twpConfig.setTargetLanguageTextTranslation(langCode)
+					translateNewInput()
+				}
+				
+				shadowRoot.querySelectorAll("#setTargetLanguage li").forEach(li => {
+					li.classList.remove("selected")
+				})
+				
+				e.target.classList.add("selected")
+			}
+		}
+  
+		eListen.onclick = () => {
+			const msgListen = chrome.i18n.getMessage("btnListen")
+			const msgStopListening = chrome.i18n.getMessage("btnStopListening")
+			
+			eListen.classList.remove("selected")
+			eListen.setAttribute("title", msgStopListening)
+			
+			if (audioDataUrls) {
+				if (isPlayingAudio) {
+					stopAudio()
+					eListen.setAttribute("title", msgListen)
+				} else {
+					isPlayingAudio = true
+					chrome.runtime.sendMessage({
+						action: "playAudio",
+						audioDataUrls
+					}, () => {
+						eListen.classList.remove("selected")
+						eListen.setAttribute("title", msgListen)
+					})
+					eListen.classList.add("selected")
+				}
+			} else {
+				stopAudio()
+				isPlayingAudio = true
+				chrome.runtime.sendMessage({
+					action: "textToSpeech",
+					text: eSelTextTrans.textContent,
+					targetLanguage: currentTargetLanguage
+				}, result => {
+					if (!result) return;
+					
+					audioDataUrls = result
+					chrome.runtime.sendMessage({
+						action: "playAudio",
+						audioDataUrls
+					}, () => {
+						isPlayingAudio = false
+						eListen.classList.remove("selected")
+						eListen.setAttribute("title", msgListen)
+					})
+				})
+				eListen.classList.add("selected")
+			}
+		}
+		
+		document.body.appendChild(divElement)
+		
+		chrome.i18n.translateDocument(shadowRoot)
+		
+		if (platformInfo.isMobile.any) {
+			eButtonTransSelText.style.width = "30px"
+			eButtonTransSelText.style.height = "30px"
+			document.addEventListener("touchstart", onTouchstart)
+		}
+		
+		eButtonTransSelText.addEventListener("click", onClick)
+		document.addEventListener("mousedown", onDown)
+		
+		const targetLanguageButtons = shadowRoot.querySelectorAll("#setTargetLanguage li")
+		
+		for (let i = 0; i < 3; i++) {
+			if (currentTargetLanguages[i] == currentTargetLanguage) {
+				targetLanguageButtons[i].classList.add("selected")
+			}
+			targetLanguageButtons[i].textContent = currentTargetLanguages[i]
+			targetLanguageButtons[i].setAttribute("value", currentTargetLanguages[i])
+			targetLanguageButtons[i].setAttribute("title", twpLang.codeToLanguage(currentTargetLanguages[i]))
+		}
+		
+		if (currentTextTranslatorService === "yandex") {
+			sYandex.classList.add("selected")
+		} else if (currentTextTranslatorService == "deepl") {
+			sDeepL.classList.add("selected")
+		} else if (currentTextTranslatorService == "bing") {
+			sBing.classList.add("selected")
+		} else {
+			sGoogle.classList.add("selected")
+		}
+		
+		if (twpConfig.get("enableDeepL") === "yes") {
+			sDeepL.removeAttribute("hidden")
+		} else {
+			sDeepL.setAttribute("hidden", "")
+		}
+		if (twpConfig.get("expandPanelTranslateSelectedText") === "yes") {
+			eOrigTextDiv.style.display = "block"
+			eMore.style.display = "none"
+			eLess.style.display = "block"
+			eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("less"))
+		} else {
+			eOrigTextDiv.style.display = "none"
+			eMore.style.display = "block"
+			eLess.style.display = "none"
+			eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("more"))
+		}
+		twpConfig.onChanged((name, newvalue) => {
+			switch (name) {
+				case "enableDeepL":
+					if (newvalue === "yes") {
+						sDeepL.removeAttribute("hidden")
+					} else {
+						sDeepL.setAttribute("hidden", "")
+					}
+					break
+				case "expandPanelTranslateSelectedText":
+					if (newvalue === "yes") {
+						eOrigTextDiv.style.display = "block"
+						eMore.style.display = "none"
+						eLess.style.display = "block"
+						eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("less"))
+					} else {
+						eOrigTextDiv.style.display = "none"
+						eMore.style.display = "block"
+						eLess.style.display = "none"
+						eMoreOrLess.setAttribute("title", chrome.i18n.getMessage("more"))
+					}
+					break
+			}
+		})
+	}
+	
+	function destroy() {
+		window.isTranslatingSelected = false
+		fooCount++
+		stopAudio()
+		audioDataUrls = null
+		if (!divElement) return;
+		
+		eButtonTransSelText.removeEventListener("click", onClick)
+		document.removeEventListener("mousedown", onDown)
+		if (platformInfo.isMobile.any) {
+			document.removeEventListener("touchstart", onTouchstart)
+		}
+		divElement.remove()
+		divElement = eButtonTransSelText = eDivResult = null
+	}
+	
+	function destroyIfButtonIsShowing(e) {
+		if (eButtonTransSelText && e.target !== divElement && eButtonTransSelText.style.display === "block") {
+			destroy()
+		}
+	}
+	
+	twpConfig.onChanged(function (name, newValue) {
+		switch (name) {
+			case "textTranslatorService":
+				currentTextTranslatorService = newValue
+				break
+			case "targetLanguages":
+				currentTargetLanguages = newValue
+				break
+			case "targetLanguageTextTranslation":
+				currentTargetLanguage = newValue
+				break
+			case "alwaysTranslateSites":
+				awaysTranslateThisSite = newValue.indexOf(tabHostName) !== -1
+				updateEventListener()
+				break
+			case "neverTranslateSites":
+				translateThisSite = newValue.indexOf(tabHostName) === -1
+				updateEventListener()
+				break
+			case "neverTranslateLangs":
+				translateThisLanguage = newValue.indexOf(originalTabLanguage) === -1
+				updateEventListener()
+				break
+			case "showTranslateSelectedButton":
+				showTranslateSelectedButton = newValue
+				updateEventListener()
+				break
+			case "dontShowIfPageLangIsTargetLang":
+				dontShowIfPageLangIsTargetLang = newValue
+				updateEventListener()
+				break
+			case "dontShowIfPageLangIsUnknown":
+				dontShowIfPageLangIsUnknown = newValue
+				updateEventListener()
+				break
+			case "dontShowIfSelectedTextIsTargetLang":
+				dontShowIfSelectedTextIsTargetLang = newValue
+				break
+			case "dontShowIfSelectedTextIsUnknown":
+				dontShowIfSelectedTextIsUnknown = newValue
+				break
+		}
+	})
+	
+	function update_eDivResult(result = "") {
+		if (eDivResult.style.display !== "block") {
+			init()
+		}
+		const eTop = prevSelectionInfo.bottom
+		const eLeft = prevSelectionInfo.left
+		
+		if (twpLang.isRtlLanguage(currentTargetLanguage)) {
+			eSelTextTrans.setAttribute("dir", "rtl")
+		} else {
+			eSelTextTrans.setAttribute("dir", "ltr")
+		}
+		eSelTextTrans.textContent = result
+		if (eDivResult.style.display !== "block") {
+			eDivResult.style.display = "block"
+			eDivResult.style.top = "0px"
+			eDivResult.style.left = "0px"
+			eOrigText.textContent = prevSelectionInfo.text
+			
+			setCaretAtEnd()
+			
+			const height = parseInt(eDivResult.offsetHeight)
+			let top = eTop + 5
+			top = Math.max(0, top)
+			top = Math.min(window.innerHeight - height, top)
+			
+			const width = parseInt(eDivResult.offsetWidth)
+			let left = parseInt(eLeft /*- width / 2*/)
+			left = Math.max(0, left)
+			left = Math.min(window.innerWidth - width, left)
+			
+			eDivResult.style.top = top + "px"
+			eDivResult.style.left = left + "px"
+		}
+	}
+	
+	function translateNewInput() {
+		fooCount++
+		let currentFooCount = fooCount
+		stopAudio()
+		audioDataUrls = null
+		
+		backgroundTranslateSingleText(currentTextTranslatorService, currentTargetLanguage, eOrigText.textContent).then(result => {
+			if (currentFooCount !== fooCount) return;
+			
+			update_eDivResult(result)
+		})
+	}
+	
+	let gSelectionInfo
+	let prevSelectionInfo
+	
+	function translateSelText(usePrevSelectionInfo = false) {
+		if (!usePrevSelectionInfo && gSelectionInfo) {
+			prevSelectionInfo = gSelectionInfo
+		} else if (!(usePrevSelectionInfo && prevSelectionInfo)) {
+			return
+		}
+		
+		eOrigText.textContent = prevSelectionInfo.text
+		
+		translateNewInput()
+		const currentFooCount = fooCount
+		setTimeout(() => {
+			if (currentFooCount !== fooCount) return;
+			update_eDivResult(eSelTextTrans.textContent)
+			fooCount = currentFooCount
+		}, 1000)
+	}
+	
+	function onClick(e) {
+		translateSelText()
+		eButtonTransSelText.style.display = "none"
+	}
+	
+	function onDown(e) {
+		if (e.target != divElement) {
+			eDivResult.style.display = "none"
+			eButtonTransSelText.style.display = "none"
+			destroy()
+		}
+	}
+	
+	
+	let isTouchSelection = false
+	
+	function onTouchstart(e) {
+		isTouchSelection = true
+		onDown(e)
+	}
+	
+	function getSelectionText() {
+		let text = "";
+		const activeEl = document.activeElement;
+		const activeElTagName = activeEl ? activeEl.tagName.toLowerCase() : null;
+		if (
+			(activeElTagName == "textarea") || (activeElTagName == "input" &&
+				/^(?:text|search)$/i.test(activeEl.type)) &&
+			(typeof activeEl.selectionStart == "number")
+		) {
+			text = activeEl.value.slice(activeEl.selectionStart, activeEl.selectionEnd);
+		} else if (window.getSelection) {
+			text = window.getSelection().toString();
+		}
+		return text;
+	}
+	
+	function readSelection(dontReadIfSelectionDontChange = false) {
+		let newSelectionInfo = null
+		
+		const activeEl = document.activeElement;
+		const activeElTagName = activeEl ? activeEl.tagName.toLowerCase() : null;
+		if (
+			(activeElTagName == "textarea") || (activeElTagName == "input" &&
+				/^(?:text|search)$/i.test(activeEl.type)) &&
+			(typeof activeEl.selectionStart == "number")
+		) {
+			const text = activeEl.value.slice(activeEl.selectionStart, activeEl.selectionEnd);
+			const rect = activeEl.getBoundingClientRect()
+			newSelectionInfo = {
+				text: text,
+				top: rect.top,
+				left: rect.left,
+				bottom: rect.bottom,
+				right: rect.right
+			}
+		} else if (window.getSelection) {
+			const selection = window.getSelection()
+			if (selection.type == "Range") {
+				const text = selection.toString();
+				const rect = selection.getRangeAt(0).getBoundingClientRect()
+				newSelectionInfo = {
+					text: text,
+					top: rect.top,
+					left: rect.left,
+					bottom: rect.bottom,
+					right: rect.right
+				}
+			}
+		}
+		
+		if (dontReadIfSelectionDontChange && gSelectionInfo && newSelectionInfo && gSelectionInfo.text === newSelectionInfo.text) {
+			gSelectionInfo = newSelectionInfo
+			return false
+		}
+		gSelectionInfo = newSelectionInfo
+		return true
+	}
+	
+	async function onUp(e) {
+		if (e.target == divElement) return;
+		
+		const clientX = Math.max((typeof e.clientX === 'undefined' ? 0 : e.clientX), (typeof e.changedTouches === 'undefined' ? 0 : e.changedTouches[0].clientX));
+		const clientY = Math.max((typeof e.clientY === 'undefined' ? 0 : e.clientY), (typeof e.changedTouches === 'undefined' ? 0 : e.changedTouches[0].clientY));
+		
+		const selectedText = getSelectionText().trim()
+		if (!selectedText || selectedText.length < 1) return;
+		let detectedLanguage = await detectTextLanguage(selectedText)
+		if (!detectedLanguage) detectedLanguage = "und";
+		
+		if (((dontShowIfSelectedTextIsTargetLang == "yes" && detectedLanguage !== currentTargetLanguage) || dontShowIfSelectedTextIsTargetLang != "yes") &&
+			((dontShowIfSelectedTextIsUnknown == "yes" && detectedLanguage !== "und") || dontShowIfSelectedTextIsUnknown != "yes")
+		) {
+			init()
+			if (platformInfo.isMobile.any) {
+				eButtonTransSelText.style.left = window.innerWidth - 45 + "px"
+				eButtonTransSelText.style.top = clientY + "px"
+			} else {
+				eButtonTransSelText.style.left = clientX + 20 + "px"
+				eButtonTransSelText.style.top = clientY - 30 + "px"
+			}
+			
+			eButtonTransSelText.style.display = "block"
+		}
+	}
+	
+	let showButtonTimerHandler = null
+	
+	function onMouseup(e) {
+		if (e.button != 0) return;
+		if (e.target == divElement) return;
+		if (readSelection(true)) {
+			clearTimeout(showButtonTimerHandler)
+			showButtonTimerHandler = setTimeout(() => onUp(e), 150)
+		}
+	}
+	
+	function onTouchend(e) {
+		if (e.target == divElement) return;
+		readSelection()
+		clearTimeout(showButtonTimerHandler)
+		showButtonTimerHandler = setTimeout(() => onUp(e), 150)
+	}
+	
+	function onSelectionchange(e) {
+		if (isTouchSelection) {
+			readSelection()
+		}
+	}
+	
+	function isSelectingText() {
+		const activeEl = document.activeElement;
+		const activeElTagName = activeEl ? activeEl.tagName.toLowerCase() : null;
+		if (
+			(activeElTagName == "textarea") || (activeElTagName == "input" &&
+				/^(?:text|search)$/i.test(activeEl.type)) &&
+			(typeof activeEl.selectionStart == "number")
+		) {
+			const text = activeEl.value.slice(activeEl.selectionStart, activeEl.selectionEnd);
+			if (text) return true;
+		} else if (window.getSelection) {
+			const selection = window.getSelection()
+			if (selection.type == "Range") {
+				const text = selection.toString();
+				if (text) return true;
+			}
+		}
+		return false
+	}
+	
+	let lastTimePressedCtrl = null
+	
+	function onKeyUp(e) {
+		if (twpConfig.get("translateSelectedWhenPressTwice") !== "yes") return;
+		if (e.key == "Control") {
+			if (lastTimePressedCtrl && performance.now() - lastTimePressedCtrl < 280 && isSelectingText()) {
+				lastTimePressedCtrl = performance.now()
+				readSelection()
+				init()
+				translateSelText()
+			}
+			lastTimePressedCtrl = performance.now()
+		}
+	}
+	
+	document.addEventListener("keyup", onKeyUp)
+	
+	let windowIsInFocus = true
+	window.addEventListener("focus", function (e) {
+		windowIsInFocus = true
+		chrome.runtime.sendMessage({action: "thisFrameIsInFocus"})
+	})
+	window.addEventListener("blur", function (e) {
+		windowIsInFocus = false
+	})
+	
+	window.addEventListener("beforeunload", function (e) {
+		destroy()
+	})
+	
+	function updateEventListener() {
+		if (showTranslateSelectedButton == "yes" && (awaysTranslateThisSite || (translateThisSite && translateThisLanguage)) &&
+			((dontShowIfPageLangIsTargetLang == "yes" && originalTabLanguage !== currentTargetLanguage) || dontShowIfPageLangIsTargetLang != "yes") &&
+			((dontShowIfPageLangIsUnknown == "yes" && originalTabLanguage !== "und") || dontShowIfPageLangIsUnknown != "yes")
+		) {
+			document.addEventListener("mouseup", onMouseup)
+			
+			document.addEventListener("blur", destroyIfButtonIsShowing)
+			document.addEventListener("visibilitychange", destroyIfButtonIsShowing)
+			
+			document.addEventListener("keydown", destroyIfButtonIsShowing)
+			document.addEventListener("mousedown", destroyIfButtonIsShowing)
+			document.addEventListener("wheel", destroyIfButtonIsShowing)
+			
+			if (platformInfo.isMobile.any) {
+				document.addEventListener("touchend", onTouchend)
+				document.addEventListener("selectionchange", onSelectionchange)
+			}
+		} else {
+			document.removeEventListener("mouseup", onMouseup)
+			
+			document.removeEventListener("blur", destroyIfButtonIsShowing)
+			document.removeEventListener("visibilitychange", destroyIfButtonIsShowing)
+			
+			document.removeEventListener("keydown", destroyIfButtonIsShowing)
+			document.removeEventListener("mousedown", destroyIfButtonIsShowing)
+			document.removeEventListener("wheel", destroyIfButtonIsShowing)
+			
+			if (platformInfo.isMobile.any) {
+				document.removeEventListener("touchend", onTouchend)
+				document.removeEventListener("selectionchange", onSelectionchange)
+			}
+		}
+	}
+	
+	updateEventListener()
+	
+	chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+		if (request.action === "TranslateSelectedText") {
+			readSelection()
+			init()
+			translateSelText()
+		} else if (request.action === "anotherFrameIsInFocus") {
+			if (!windowIsInFocus) {
+				destroy()
+			}
+		}
+	})
 })

--- a/contentScript/translateSelected.js
+++ b/contentScript/translateSelected.js
@@ -230,13 +230,13 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                         background-color: rgba(0, 0, 0, 0.5);
                     }
                     li {
-                    	background-color: rgba(0, 0, 0, 0.4);
+                    	background-color: rgba(255, 255, 255, 0.1);
                     }
                     .selected {
-                    	background-color: rgba(0, 0, 0, 0.7);
+                    	background-color: rgba(255, 255, 255, 0.3);
                     }
                     #moreOrLess {
-                		background-color: rgba(0, 0, 0, 0.4);
+                		background-color: rgba(255, 255, 255, 0.1);
             		}
             		hr {
             			border: 1px black solid;

--- a/contentScript/translateSelected.js
+++ b/contentScript/translateSelected.js
@@ -206,6 +206,18 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                         backdrop-filter: none;
                         background-color: rgba(0, 0, 0, 0.85);
                     }
+                    li {
+                    	background-color: rgba(255, 255, 255, 0.1);
+                    }
+                    .selected {
+                    	background-color: rgba(255, 255, 255, 0.4);
+                    }
+                    #moreOrLess {
+                		background-color: rgba(255, 255, 255, 0.1);
+            		}
+            		hr {
+            			border: 1px rgba(255, 255, 255, 0.5) solid;
+            		}
                 `
             shadowRoot.appendChild(el)
         }else{
@@ -217,6 +229,18 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                         backdrop-filter: blur(3px);
                         background-color: rgba(0, 0, 0, 0.5);
                     }
+                    li {
+                    	background-color: rgba(0, 0, 0, 0.4);
+                    }
+                    .selected {
+                    	background-color: rgba(0, 0, 0, 0.7);
+                    }
+                    #moreOrLess {
+                		background-color: rgba(0, 0, 0, 0.4);
+            		}
+            		hr {
+            			border: 1px black solid;
+            		}
                 `
             shadowRoot.appendChild(el)
         }
@@ -240,9 +264,10 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
         
         eCopy.onclick = () => {
             navigator.clipboard.writeText(eSelTextTrans.textContent).then(() => {
+				const oldBackgroundColor = eCopy.style.backgroundColor
                 eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"
                 setTimeout(() => {
-                    eCopy.style.backgroundColor = "rgba(0, 0, 0, 0.4)"
+                    eCopy.style.backgroundColor = oldBackgroundColor
                 }, 500)
             })
         }

--- a/contentScript/translateSelected.js
+++ b/contentScript/translateSelected.js
@@ -149,19 +149,8 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                     <hr>
                 </div>
                 <div id="eSelTextTrans" dir="auto"></div>
-                <div id="drag">
-                    <ul id="setTargetLanguage">
-                        <li value="en" title="English">en</li>
-                        <li value="es" title="Spanish">es</li>
-                        <li value="de" title="German">de</li>
-                    </ul>
-                    <div id="moreOrLess"><i class="arrow up" id="more"></i><i class="arrow down" id="less"></i></div>
-                    <ul>
-                        <li title="Google" id="sGoogle">g</li>
-                        <li title="Yandex" id="sYandex">y</li>
-                        <li title="Bing" id="sBing">b</li>
-                        <li title="DeepL" id="sDeepL" hidden>d</li>
-                        <li title="Copy" data-i18n-title="btnCopy" id="copy">
+                <div style="float: right">
+                <li title="Copy" data-i18n-title="btnCopy" id="copy">
                             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M13 7H7V5H13V7Z" fill="currentColor" />
                             <path d="M13 11H7V9H13V11Z" fill="currentColor" />
@@ -169,6 +158,7 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                             <path fill-rule="evenodd" clip-rule="evenodd" d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
                             </svg>
                         </li>
+                        <br>
                         <li title="Listen" data-i18n-title="btnListen" id="listen">
                             <svg id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
                             width="10px" height="10px" viewBox="0 0 93.038 93.038" xml:space="preserve" style="fill: rgb(255, 255, 255)">
@@ -187,21 +177,35 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                             </g>
                             </svg>
                         </li>
+                        </div>
+                        <br>
+                <div id="drag">
+                    <ul id="setTargetLanguage">
+                        <li value="en" title="English">en</li>
+                        <li value="es" title="Spanish">es</li>
+                        <li value="de" title="German">de</li>
+                    </ul>
+                    <div id="moreOrLess"><i class="arrow up" id="more"></i><i class="arrow down" id="less"></i></div>
+                    <ul>
+                        <li title="Google" id="sGoogle">g</li>
+                        <li title="Yandex" id="sYandex">y</li>
+                        <li title="Bing" id="sBing">b</li>
+                        <li title="DeepL" id="sDeepL" hidden>d</li>
                     </ul>
                 </div>
             </div>
         `
-        const style = document.createElement("style")
-        style.textContent = styleTextContent
-        shadowRoot.insertBefore(style, shadowRoot.getElementById("eButtonTransSelText"))
+		const style = document.createElement("style")
+		style.textContent = styleTextContent
+		shadowRoot.insertBefore(style, shadowRoot.getElementById("eButtonTransSelText"))
 		
 		dragElement(shadowRoot.getElementById("eDivResult"), shadowRoot.getElementById("drag"))
 		
-        if (!CSS.supports("backdrop-filter: blur(5px)")) {
-            const el = document.createElement("style")
-            el.setAttribute("id", "backdropFilterElement")
-            el.setAttribute("rel", "stylesheet")
-            el.textContent = `
+		if (!CSS.supports("backdrop-filter: blur(5px)")) {
+			const el = document.createElement("style")
+			el.setAttribute("id", "backdropFilterElement")
+			el.setAttribute("rel", "stylesheet")
+			el.textContent = `
                     #eDivResult {
                         backdrop-filter: none;
                         background-color: rgba(0, 0, 0, 0.85);
@@ -219,12 +223,12 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
             			border: 1px rgba(255, 255, 255, 0.5) solid;
             		}
                 `
-            shadowRoot.appendChild(el)
-        }else{
-            const el = document.createElement("style")
-            el.setAttribute("id", "backdropFilterElement")
-            el.setAttribute("rel", "stylesheet")
-            el.textContent = `
+			shadowRoot.appendChild(el)
+		} else {
+			const el = document.createElement("style")
+			el.setAttribute("id", "backdropFilterElement")
+			el.setAttribute("rel", "stylesheet")
+			el.textContent = `
                     #eDivResult {
                         backdrop-filter: blur(3px);
                         background-color: rgba(0, 0, 0, 0.5);
@@ -242,8 +246,8 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
             			border: 1px black solid;
             		}
                 `
-            shadowRoot.appendChild(el)
-        }
+			shadowRoot.appendChild(el)
+		}
 		
 		eButtonTransSelText = shadowRoot.getElementById("eButtonTransSelText")
 		eDivResult = shadowRoot.getElementById("eDivResult")
@@ -259,18 +263,18 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
 		const sYandex = shadowRoot.getElementById("sYandex")
 		const sBing = shadowRoot.getElementById("sBing")
 		const sDeepL = shadowRoot.getElementById("sDeepL")
-        const eCopy = shadowRoot.getElementById("copy")
-        const eListen = shadowRoot.getElementById("listen")
-        
-        eCopy.onclick = () => {
-            navigator.clipboard.writeText(eSelTextTrans.textContent).then(() => {
+		const eCopy = shadowRoot.getElementById("copy")
+		const eListen = shadowRoot.getElementById("listen")
+		
+		eCopy.onclick = () => {
+			navigator.clipboard.writeText(eSelTextTrans.textContent).then(() => {
 				const oldBackgroundColor = eCopy.style.backgroundColor
-                eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"
-                setTimeout(() => {
-                    eCopy.style.backgroundColor = oldBackgroundColor
-                }, 500)
-            })
-        }
+				eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"
+				setTimeout(() => {
+					eCopy.style.backgroundColor = oldBackgroundColor
+				}, 500)
+			})
+		}
 		
 		eOrigText.onkeypress = e => {
 			e.stopPropagation()
@@ -362,7 +366,7 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
 				e.target.classList.add("selected")
 			}
 		}
-  
+		
 		eListen.onclick = () => {
 			const msgListen = chrome.i18n.getMessage("btnListen")
 			const msgStopListening = chrome.i18n.getMessage("btnStopListening")

--- a/contentScript/translateSelected.js
+++ b/contentScript/translateSelected.js
@@ -149,7 +149,7 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                     <hr>
                 </div>
                 <div id="eSelTextTrans" dir="auto"></div>
-                <div style="float: right">
+                <div style="float: right;list-style-type: none;">
                 <li title="Copy" data-i18n-title="btnCopy" id="copy">
                             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M13 7H7V5H13V7Z" fill="currentColor" />
@@ -160,22 +160,22 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                         </li>
                         <br>
                         <li title="Listen" data-i18n-title="btnListen" id="listen">
-                            <svg id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                            width="10px" height="10px" viewBox="0 0 93.038 93.038" xml:space="preserve" style="fill: rgb(255, 255, 255)">
-                            <g>
-                                <path d="M46.547,75.521c0,1.639-0.947,3.128-2.429,3.823c-0.573,0.271-1.187,0.402-1.797,0.402c-0.966,0-1.923-0.332-2.696-0.973
-                                    l-23.098-19.14H4.225C1.892,59.635,0,57.742,0,55.409V38.576c0-2.334,1.892-4.226,4.225-4.226h12.303l23.098-19.14
-                                    c1.262-1.046,3.012-1.269,4.493-0.569c1.481,0.695,2.429,2.185,2.429,3.823L46.547,75.521L46.547,75.521z M62.784,68.919
-                                    c-0.103,0.007-0.202,0.011-0.304,0.011c-1.116,0-2.192-0.441-2.987-1.237l-0.565-0.567c-1.482-1.479-1.656-3.822-0.408-5.504
-                                    c3.164-4.266,4.834-9.323,4.834-14.628c0-5.706-1.896-11.058-5.484-15.478c-1.366-1.68-1.24-4.12,0.291-5.65l0.564-0.565
-                                    c0.844-0.844,1.975-1.304,3.199-1.231c1.192,0.06,2.305,0.621,3.061,1.545c4.977,6.09,7.606,13.484,7.606,21.38
-                                    c0,7.354-2.325,14.354-6.725,20.24C65.131,68.216,64.007,68.832,62.784,68.919z M80.252,81.976
-                                    c-0.764,0.903-1.869,1.445-3.052,1.495c-0.058,0.002-0.117,0.004-0.177,0.004c-1.119,0-2.193-0.442-2.988-1.237l-0.555-0.555
-                                    c-1.551-1.55-1.656-4.029-0.246-5.707c6.814-8.104,10.568-18.396,10.568-28.982c0-11.011-4.019-21.611-11.314-29.847
-                                    c-1.479-1.672-1.404-4.203,0.17-5.783l0.554-0.555c0.822-0.826,1.89-1.281,3.115-1.242c1.163,0.033,2.263,0.547,3.036,1.417
-                                    c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z"/>
-                            </g>
-                            </svg>
+                            <svg id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="10px" height="10px" viewBox="0 0 93.038 93.038"
+                 style="enable-background:new 0 0 93.038 93.038;fill: white" xml:space="preserve">
+                        <g>
+                            <path d="M46.547,75.521c0,1.639-0.947,3.128-2.429,3.823c-0.573,0.271-1.187,0.402-1.797,0.402c-0.966,0-1.923-0.332-2.696-0.973
+                            l-23.098-19.14H4.225C1.892,59.635,0,57.742,0,55.409V38.576c0-2.334,1.892-4.226,4.225-4.226h12.303l23.098-19.14
+                            c1.262-1.046,3.012-1.269,4.493-0.569c1.481,0.695,2.429,2.185,2.429,3.823L46.547,75.521L46.547,75.521z M62.784,68.919
+                            c-0.103,0.007-0.202,0.011-0.304,0.011c-1.116,0-2.192-0.441-2.987-1.237l-0.565-0.567c-1.482-1.479-1.656-3.822-0.408-5.504
+                            c3.164-4.266,4.834-9.323,4.834-14.628c0-5.706-1.896-11.058-5.484-15.478c-1.366-1.68-1.24-4.12,0.291-5.65l0.564-0.565
+                            c0.844-0.844,1.975-1.304,3.199-1.231c1.192,0.06,2.305,0.621,3.061,1.545c4.977,6.09,7.606,13.484,7.606,21.38
+                            c0,7.354-2.325,14.354-6.725,20.24C65.131,68.216,64.007,68.832,62.784,68.919z M80.252,81.976
+                            c-0.764,0.903-1.869,1.445-3.052,1.495c-0.058,0.002-0.117,0.004-0.177,0.004c-1.119,0-2.193-0.442-2.988-1.237l-0.555-0.555
+                            c-1.551-1.55-1.656-4.029-0.246-5.707c6.814-8.104,10.568-18.396,10.568-28.982c0-11.011-4.019-21.611-11.314-29.847
+                            c-1.479-1.672-1.404-4.203,0.17-5.783l0.554-0.555c0.822-0.826,1.89-1.281,3.115-1.242c1.163,0.033,2.263,0.547,3.036,1.417
+                            c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z"/>
+                        </g>
+                    </svg>
                         </li>
                         </div>
                         <br>
@@ -201,30 +201,7 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
 		
 		dragElement(shadowRoot.getElementById("eDivResult"), shadowRoot.getElementById("drag"))
 		
-		if (!CSS.supports("backdrop-filter: blur(5px)")) {
-			const el = document.createElement("style")
-			el.setAttribute("id", "backdropFilterElement")
-			el.setAttribute("rel", "stylesheet")
-			el.textContent = `
-                    #eDivResult {
-                        backdrop-filter: none;
-                        background-color: rgba(0, 0, 0, 0.85);
-                    }
-                    li {
-                    	background-color: rgba(255, 255, 255, 0.1);
-                    }
-                    .selected {
-                    	background-color: rgba(255, 255, 255, 0.4);
-                    }
-                    #moreOrLess {
-                		background-color: rgba(255, 255, 255, 0.1);
-            		}
-            		hr {
-            			border: 1px rgba(255, 255, 255, 0.5) solid;
-            		}
-                `
-			shadowRoot.appendChild(el)
-		} else {
+		if (CSS.supports("backdrop-filter: blur(5px)")) {
 			const el = document.createElement("style")
 			el.setAttribute("id", "backdropFilterElement")
 			el.setAttribute("rel", "stylesheet")
@@ -243,7 +220,30 @@ Promise.all([ twpConfig.onReady(), getTabHostName() ]).then(function (_) {
                 		background-color: rgba(255, 255, 255, 0.1);
             		}
             		hr {
-            			border: 1px black solid;
+            			border: 1px rgba(255, 255, 255, 0.5) solid;
+            		}
+                `
+			shadowRoot.appendChild(el)
+		} else {
+			const el = document.createElement("style")
+			el.setAttribute("id", "backdropFilterElement")
+			el.setAttribute("rel", "stylesheet")
+			el.textContent = `
+                    #eDivResult {
+                        backdrop-filter: none;
+                        background-color: rgba(0, 0, 0, 0.925);
+                    }
+                    li {
+                    	background-color: rgba(255, 255, 255, 0.1);
+                    }
+                    .selected {
+                    	background-color: rgba(255, 255, 255, 0.4);
+                    }
+                    #moreOrLess {
+                		background-color: rgba(255, 255, 255, 0.1);
+            		}
+            		hr {
+            			border: 1px rgba(255, 255, 255, 0.75) solid;
             		}
                 `
 			shadowRoot.appendChild(el)

--- a/popup/popup-translate-text.html
+++ b/popup/popup-translate-text.html
@@ -5,9 +5,23 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
+    
     <style>
-        #eTextTranslated, #eOrigText {
+        * {
+            scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0);
+        }
+
+        body {
+            color: white;
+            font-family: Arial, sans-serif;
+            font-style: normal;
+            font-variant: normal;
+            font-weight: 500;
+            background-color: rgb(28, 27, 27);
+        }
+    
+        #eTextTranslated,
+        #eOrigText {
             padding: 14px;
             font-size: 16px;
             max-width: 360px;
@@ -15,68 +29,89 @@
             overflow: auto;
             white-space: pre-wrap;
         }
-
+    
         #eOrigText {
             outline: none;
         }
-
+    
         ul {
-            margin: 0px;
+            margin: 0;
             padding: 3px;
             list-style-type: none;
             overflow: hidden;
             user-select: none;
         }
-
+    
         li {
-            margin: 3px;
+            margin: 5px;
             float: left;
             cursor: pointer;
             text-align: center;
+            vertical-align: middle;
             padding: 4px 6px;
-            border-radius: 6px;
-            box-shadow: 0 0 2px 0px #999;
+            border-radius: 5px;
+            box-shadow: 0 0 3px -2px black;
+            background-color: rgba(0, 0, 0, 0.3);
+            border: none;
+            transition: 0.2s;
         }
-
+    
         li:hover {
-            background-color: #ccc;
+            transform: translateY(-1px);
         }
-
+    
         hr {
-            border: 1px solid #ddd;
+            width: 90%;
+            border: 1px black solid;
+        }
+    
+        .selected {
+            background-color: rgba(0, 0, 0, 0.8);
+            border: none;
+        }
+        
+        #eOrigTextDiv {
+            display: none;
+        }
+        
+        #listen {
+            padding-top: 6px;
+            padding-bottom: 2px;
         }
 
-        .selected {
-            background-color: #ccc;
-        }
     </style>
 </head>
 
 <body>
-    <div>
-        <div id="eOrigTextDiv">
-            <div id="eOrigText" contentEditable="true" spellcheck="false" dir="auto"></div>
-            <hr>
-        </div>
-        <div id="eTextTranslated" dir="auto"></div>
+<div>
+    <div id="eOrigTextDiv">
+        <div id="eOrigText" contentEditable="true" spellcheck="false" dir="auto"></div>
         <hr>
-        <div style="display: flex; justify-content: space-between; flex-direction:row;">
-            <ul id="setTargetLanguage">
-                <li value="en" title="English">en</li>
-                <li value="es" title="Spanish">es</li>
-                <li value="de" title="German">de</li>
-            </ul>
-            <ul>
-                <li title="Google" id="sGoogle">g</li>
-                <li title="Yandex" id="sYandex">y</li>
-                <li title="Bing" id="sBing">b</li>
-                <li title="DeepL" id="sDeepL" hidden>d</li>
-                <li style="padding-top: 6px; padding-bottom: 2px;" title="Listen" data-i18n-title="btnListen"
-                    id="listen">
-                    <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg"
-                        xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="14px" height="12px"
-                        viewBox="0 0 93.038 93.038" style="enable-background:new 0 0 93.038 93.038;"
-                        xml:space="preserve">
+    </div>
+    <div id="eTextTranslated" dir="auto"></div>
+    <div style="display: flex; justify-content: space-between; flex-direction:row;">
+        <ul id="setTargetLanguage">
+            <li value="en" title="English">en</li>
+            <li value="es" title="Spanish">es</li>
+            <li value="de" title="German">de</li>
+        </ul>
+        <ul>
+            <li title="Google" id="sGoogle">g</li>
+            <li title="Yandex" id="sYandex">y</li>
+            <li title="Bing" id="sBing">b</li>
+            <li title="DeepL" id="sDeepL" hidden>d</li>
+            <li title="Copy" data-i18n-title="btnCopy" id="copy">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M13 7H7V5H13V7Z" fill="currentColor"/>
+                    <path d="M13 11H7V9H13V11Z" fill="currentColor"/>
+                    <path d="M7 15H13V13H7V15Z" fill="currentColor"/>
+                    <path fill-rule="evenodd" clip-rule="evenodd"
+                          d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
+                </svg>
+            </li>
+            <li style="padding-top: 6px; padding-bottom: 2px;fill: white;" title="Listen" data-i18n-title="btnListen"
+                id="listen">
+                <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="14px" height="12px" viewBox="0 0 93.038 93.038" style="enable-background:new 0 0 93.038 93.038;" xml:space="preserve">
                         <g>
                             <path d="M46.547,75.521c0,1.639-0.947,3.128-2.429,3.823c-0.573,0.271-1.187,0.402-1.797,0.402c-0.966,0-1.923-0.332-2.696-0.973
                             l-23.098-19.14H4.225C1.892,59.635,0,57.742,0,55.409V38.576c0-2.334,1.892-4.226,4.225-4.226h12.303l23.098-19.14
@@ -88,48 +123,18 @@
                             c-0.764,0.903-1.869,1.445-3.052,1.495c-0.058,0.002-0.117,0.004-0.177,0.004c-1.119,0-2.193-0.442-2.988-1.237l-0.555-0.555
                             c-1.551-1.55-1.656-4.029-0.246-5.707c6.814-8.104,10.568-18.396,10.568-28.982c0-11.011-4.019-21.611-11.314-29.847
                             c-1.479-1.672-1.404-4.203,0.17-5.783l0.554-0.555c0.822-0.826,1.89-1.281,3.115-1.242c1.163,0.033,2.263,0.547,3.036,1.417
-                            c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z" />
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
-                        </g>
-                        <g>
+                            c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z"/>
                         </g>
                     </svg>
-                </li>
-            </ul>
-        </div>
+            </li>
+        </ul>
     </div>
+</div>
 
-    <script src="/lib/languages.js"></script>
-    <script src="/lib/config.js"></script>
-    <script src="/lib/i18n.js"></script>
-    <script src="popup-translate-text.js"></script>
+<script src="/lib/languages.js"></script>
+<script src="/lib/config.js"></script>
+<script src="/lib/i18n.js"></script>
+<script src="popup-translate-text.js"></script>
 </body>
 
 </html>

--- a/popup/popup-translate-text.html
+++ b/popup/popup-translate-text.html
@@ -19,6 +19,10 @@
             font-weight: 500;
             background-color: rgb(28, 27, 27);
         }
+        
+        #eTextTranslated {
+            width: 200px;
+        }
     
         #eTextTranslated,
         #eOrigText {
@@ -72,6 +76,7 @@
         
         #eOrigTextDiv {
             display: none;
+            max-width: 200px;
         }
         
         #listen {
@@ -88,30 +93,23 @@
         <div id="eOrigText" contentEditable="true" spellcheck="false" dir="auto"></div>
         <hr>
     </div>
-    <div id="eTextTranslated" dir="auto"></div>
-    <div style="display: flex; justify-content: space-between; flex-direction:row;">
-        <ul id="setTargetLanguage">
-            <li value="en" title="English">en</li>
-            <li value="es" title="Spanish">es</li>
-            <li value="de" title="German">de</li>
-        </ul>
-        <ul>
-            <li title="Google" id="sGoogle">g</li>
-            <li title="Yandex" id="sYandex">y</li>
-            <li title="Bing" id="sBing">b</li>
-            <li title="DeepL" id="sDeepL" hidden>d</li>
-            <li title="Copy" data-i18n-title="btnCopy" id="copy">
-                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M13 7H7V5H13V7Z" fill="currentColor"/>
-                    <path d="M13 11H7V9H13V11Z" fill="currentColor"/>
-                    <path d="M7 15H13V13H7V15Z" fill="currentColor"/>
-                    <path fill-rule="evenodd" clip-rule="evenodd"
-                          d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
-                </svg>
-            </li>
-            <li style="padding-top: 6px; padding-bottom: 2px;fill: white;" title="Listen" data-i18n-title="btnListen"
-                id="listen">
-                <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="14px" height="12px" viewBox="0 0 93.038 93.038" style="enable-background:new 0 0 93.038 93.038;" xml:space="preserve">
+    <div id="eTextTranslated" dir="auto" style="float: left"></div>
+    <div style="float: right">
+        <li title="Copy" data-i18n-title="btnCopy" id="copy">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M13 7H7V5H13V7Z" fill="currentColor"/>
+                <path d="M13 11H7V9H13V11Z" fill="currentColor"/>
+                <path d="M7 15H13V13H7V15Z" fill="currentColor"/>
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                      d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
+            </svg>
+        </li>
+        <br>
+        <li style="padding-top: 6px; padding-bottom: 2px;fill: white;" title="Listen" data-i18n-title="btnListen"
+            id="listen">
+            <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+                 x="0px" y="0px" width="14px" height="12px" viewBox="0 0 93.038 93.038"
+                 style="enable-background:new 0 0 93.038 93.038;" xml:space="preserve">
                         <g>
                             <path d="M46.547,75.521c0,1.639-0.947,3.128-2.429,3.823c-0.573,0.271-1.187,0.402-1.797,0.402c-0.966,0-1.923-0.332-2.696-0.973
                             l-23.098-19.14H4.225C1.892,59.635,0,57.742,0,55.409V38.576c0-2.334,1.892-4.226,4.225-4.226h12.303l23.098-19.14
@@ -126,7 +124,20 @@
                             c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z"/>
                         </g>
                     </svg>
-            </li>
+        </li>
+    </div>
+    <br>
+    <div style="display: flex; justify-content: space-between; flex-direction:row;width: 275px">
+        <ul id="setTargetLanguage">
+            <li value="en" title="English">en</li>
+            <li value="es" title="Spanish">es</li>
+            <li value="de" title="German">de</li>
+        </ul>
+        <ul>
+            <li title="Google" id="sGoogle">g</li>
+            <li title="Yandex" id="sYandex">y</li>
+            <li title="Bing" id="sBing">b</li>
+            <li title="DeepL" id="sDeepL" hidden>d</li>
         </ul>
     </div>
 </div>

--- a/popup/popup-translate-text.html
+++ b/popup/popup-translate-text.html
@@ -8,7 +8,7 @@
     
     <style>
         * {
-            scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0);
+            scrollbar-color: rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.2);
         }
 
         body {
@@ -65,8 +65,8 @@
         }
     
         hr {
-            width: 90%;
-            border: 1px black solid;
+            width: 95%;
+            border: 1px rgba(255, 255, 255, 0.75) solid;
         }
     
         .selected {
@@ -75,7 +75,6 @@
         }
         
         #eOrigTextDiv {
-            display: none;
             max-width: 200px;
         }
         
@@ -91,24 +90,23 @@
 <div>
     <div id="eOrigTextDiv">
         <div id="eOrigText" contentEditable="true" spellcheck="false" dir="auto"></div>
-        <hr>
     </div>
-    <div id="eTextTranslated" dir="auto" style="float: left"></div>
-    <div style="float: right">
+    <hr>
+    <div id="eTextTranslated" dir="auto" style="float: left;"></div>
+    <div style="float: right;list-style-type: none;">
         <li title="Copy" data-i18n-title="btnCopy" id="copy">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M13 7H7V5H13V7Z" fill="currentColor"/>
                 <path d="M13 11H7V9H13V11Z" fill="currentColor"/>
                 <path d="M7 15H13V13H7V15Z" fill="currentColor"/>
-                <path fill-rule="evenodd" clip-rule="evenodd"
-                      d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M3 19V1H17V5H21V23H7V19H3ZM15 17V3H5V17H15ZM17 7V19H9V21H19V7H17Z" fill="currentColor"/>
             </svg>
         </li>
         <br>
         <li style="padding-top: 6px; padding-bottom: 2px;fill: white;" title="Listen" data-i18n-title="btnListen"
             id="listen">
             <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-                 x="0px" y="0px" width="14px" height="12px" viewBox="0 0 93.038 93.038"
+                 x="0px" y="0px" width="10px" height="10px" viewBox="0 0 93.038 93.038"
                  style="enable-background:new 0 0 93.038 93.038;" xml:space="preserve">
                         <g>
                             <path d="M46.547,75.521c0,1.639-0.947,3.128-2.429,3.823c-0.573,0.271-1.187,0.402-1.797,0.402c-0.966,0-1.923-0.332-2.696-0.973
@@ -123,7 +121,7 @@
                             c-1.479-1.672-1.404-4.203,0.17-5.783l0.554-0.555c0.822-0.826,1.89-1.281,3.115-1.242c1.163,0.033,2.263,0.547,3.036,1.417
                             c8.818,9.928,13.675,22.718,13.675,36.01C93.04,59.783,88.499,72.207,80.252,81.976z"/>
                         </g>
-                    </svg>
+            </svg>
         </li>
     </div>
     <br>

--- a/popup/popup-translate-text.js
+++ b/popup/popup-translate-text.js
@@ -92,8 +92,6 @@ twpConfig.onReady(function () {
     const eCopy = document.getElementById("copy")
     const eListen = document.getElementById("listen")
     
-    eOrigText.innerHTML =
-    
     eCopy.onclick = () => {
         navigator.clipboard.writeText(eTextTranslated.textContent).then(async () => {
             eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"

--- a/popup/popup-translate-text.js
+++ b/popup/popup-translate-text.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var $ = document.querySelector.bind(document)
+let $ = document.querySelector.bind(document);
 
 twpConfig.onReady(function () {
     function backgroundTranslateSingleText(translationService, targetLanguage, source) {
@@ -32,6 +32,10 @@ twpConfig.onReady(function () {
             }
             .selected {
                 background-color: rgba(0, 0, 0, 0.6) !important;
+            }
+            hr {
+                width: 95%;
+                border: 1px rgba(0, 0, 0, 0.75) solid;
             }
             `
             document.body.appendChild(el)
@@ -88,8 +92,10 @@ twpConfig.onReady(function () {
     const eCopy = document.getElementById("copy")
     const eListen = document.getElementById("listen")
     
+    eOrigText.innerHTML =
+    
     eCopy.onclick = () => {
-        navigator.clipboard.writeText(eTextTranslated.textContent).then(() => {
+        navigator.clipboard.writeText(eTextTranslated.textContent).then(async () => {
             eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"
             setTimeout(() => {
                 eCopy.style.backgroundColor = "rgba(0, 0, 0, 0.4)"
@@ -239,14 +245,22 @@ twpConfig.onReady(function () {
         targetLanguageButtons[i].setAttribute("title", twpLang.codeToLanguage(currentTargetLanguages[i]))
     }
 
-    if (currentTextTranslatorService === "yandex") {
-        sYandex.classList.add("selected")
-    } else if (currentTextTranslatorService == "deepl") {
-        sDeepL.classList.add("selected")
-    } else if (currentTextTranslatorService == "bing") {
-        sBing.classList.add("selected")
-    } else {
-        sGoogle.classList.add("selected")
+    switch (currentTextTranslatorService) {
+        case "yandex":
+            sYandex.classList.add("selected")
+            break
+        case "deepl":
+            sDeepL.classList.add("selected")
+            break
+        case "bing":
+            sBing.classList.add("selected")
+            break
+        case "google":
+            sGoogle.classList.add("selected")
+            break
+        default:
+            sGoogle.classList.add("selected")
+            break
     }
 
     if (twpConfig.get("enableDeepL") === "yes") {

--- a/popup/popup-translate-text.js
+++ b/popup/popup-translate-text.js
@@ -20,60 +20,6 @@ twpConfig.onReady(function () {
     let currentTargetLanguage = twpConfig.get("targetLanguageTextTranslation")
     let currentTextTranslatorService = twpConfig.get("textTranslatorService")
 
-    function enableDarkMode() {
-        if (!document.getElementById("darkModeElement")) {
-            const el = document.createElement("style")
-            el.setAttribute("id", "darkModeElement")
-            el.setAttribute("rel", "stylesheet")
-            el.textContent = `
-            * {
-                scrollbar-color: #202324 #454a4d;
-            }
-            body {
-                color: rgb(231, 230, 228) !important;
-                background-color: #181a1b !important;
-            }
-            hr {
-                border-color: #666;
-            }
-            li:hover {
-                color: rgb(231, 230, 228) !important;
-                background-color: #454a4d !important;
-            }
-            .selected {
-                background-color: #454a4d !important;
-            }
-            `
-            document.body.appendChild(el)
-            document.querySelector("#listen svg").style = "fill: rgb(231, 230, 228)"
-        }
-    }
-
-    function disableDarkMode() {
-        if (document.getElementById("#darkModeElement")) {
-            document.getElementById("#darkModeElement").remove()
-            document.querySelector("#listen svg").style = "fill: black"
-        }
-    }
-
-    switch (twpConfig.get("darkMode")) {
-        case "auto":
-            if (matchMedia("(prefers-color-scheme: dark)").matches) {
-                enableDarkMode()
-            } else {
-                disableDarkMode()
-            }
-            break
-        case "yes":
-            enableDarkMode()
-            break
-        case "no":
-            disableDarkMode()
-            break
-        default:
-            break
-    }
-
     let audioDataUrls = null
     let isPlayingAudio = false
 
@@ -95,7 +41,18 @@ twpConfig.onReady(function () {
     const sYandex = document.getElementById("sYandex")
     const sBing = document.getElementById("sBing")
     const sDeepL = document.getElementById("sDeepL")
-
+    const eCopy = document.getElementById("copy")
+    const eListen = document.getElementById("listen")
+    
+    eCopy.onclick = () => {
+        navigator.clipboard.writeText(eTextTranslated.textContent).then(() => {
+            eCopy.style.backgroundColor = "rgba(0, 255, 0, 0.4)"
+            setTimeout(() => {
+                eCopy.style.backgroundColor = "rgba(0, 0, 0, 0.4)"
+            }, 500)
+        })
+    }
+    
     function setCaretAtEnd() {
         const el = eOrigText
         const range = document.createRange()
@@ -106,7 +63,7 @@ twpConfig.onReady(function () {
         sel.addRange(range)
         el.focus()
     }
-
+    
     let translateNewInputTimerHandler
     eOrigText.oninput = () => {
         clearTimeout(translateNewInputTimerHandler)
@@ -179,8 +136,7 @@ twpConfig.onReady(function () {
             e.target.classList.add("selected")
         }
     }
-
-    const eListen = document.getElementById("listen")
+    
     eListen.classList.remove("selected")
     eListen.onclick = () => {
         const msgListen = chrome.i18n.getMessage("btnListen")

--- a/popup/popup-translate-text.js
+++ b/popup/popup-translate-text.js
@@ -19,7 +19,51 @@ twpConfig.onReady(function () {
     let currentTargetLanguages = twpConfig.get("targetLanguages")
     let currentTargetLanguage = twpConfig.get("targetLanguageTextTranslation")
     let currentTextTranslatorService = twpConfig.get("textTranslatorService")
-
+    
+    function disableDarkMode() {
+        if (!document.getElementById("lightModeElement")) {
+            const el = document.createElement("style")
+            el.setAttribute("id", "lightModeElement")
+            el.setAttribute("rel", "stylesheet")
+            el.textContent = `
+            body {
+                color: rgb(0, 0, 0) !important;
+                background-color: rgb(215, 215, 215) !important;
+            }
+            .selected {
+                background-color: rgba(0, 0, 0, 0.6) !important;
+            }
+            `
+            document.body.appendChild(el)
+            document.querySelector("#listen svg").style = "fill: rgb(0, 0, 0)"
+        }
+    }
+    
+    function enableDarkMode() {
+        if (document.getElementById("#lightModeElement")) {
+            document.getElementById("#lightModeElement").remove()
+            document.querySelector("#listen svg").style = "fill: black"
+        }
+    }
+    
+    switch (twpConfig.get("darkMode")) {
+        case "auto":
+            if (matchMedia("(prefers-color-scheme: dark)").matches) {
+                enableDarkMode()
+            } else {
+                disableDarkMode()
+            }
+            break
+        case "yes":
+            enableDarkMode()
+            break
+        case "no":
+            disableDarkMode()
+            break
+        default:
+            break
+    }
+    
     let audioDataUrls = null
     let isPlayingAudio = false
 


### PR DESCRIPTION
Hi, this pull request completely revamps the translate text popup. I didn't touch the popup for sites that don't allow inject scripts.
It adds a gaussian blurred background if the browser supports it, and more design enhancements.
Chromium browsers support the gaussian blurred background by default, but in Firefox you should change `layout.css.backdrop-filter.enabled` in about:config. If not enabled, there will be a black background with 20% transparency.
Also, it adds a copy button. (Issue #319)
I removed the dark/light mode thing because there's no need, there's a transparent background.