### PR TITLE
Added support for "about:blank"

### DIFF
--- a/chrome_manifest.json
+++ b/chrome_manifest.json
@@ -75,12 +75,14 @@
             "matches": ["<all_urls>"],
             "run_at": "document_start",
             "all_frames": true,
+            "match_about_blank": true,
             "js": ["/lib/languages.js", "/lib/config.js", "/lib/platformInfo.js"]
         },
         {
             "matches": ["<all_urls>"],
             "run_at": "document_end",
             "all_frames": true,
+            "match_about_blank": true,
             "js": ["/lib/i18n.js", "/contentScript/showOriginal.js", "/contentScript/pageTranslator.js", "/contentScript/translateSelected.js", "/contentScript/showTranslated.js"]
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -112,12 +112,14 @@
             "matches": ["<all_urls>"],
             "run_at": "document_start",
             "all_frames": true,
+            "match_about_blank": true,
             "js": ["/lib/languages.js", "/lib/config.js", "/lib/platformInfo.js"]
         },
         {
             "matches": ["<all_urls>"],
             "run_at": "document_end",
             "all_frames": true,
+            "match_about_blank": true,
             "js": ["/lib/i18n.js", "/contentScript/showOriginal.js", "/contentScript/pageTranslator.js", "/contentScript/translateSelected.js", "/contentScript/showTranslated.js"]
         },
         {


### PR DESCRIPTION
Test cases:
```js
document.body.insertAdjacentHTML('beforeend','<iframe srcdoc="text"></iframe>')
```

The content script of WebExtensions can be loaded into this iframe.