### PR TITLE
[Bugfix] Add support for "reset" input type

### DIFF
--- a/contentScript/pageTranslator.js
+++ b/contentScript/pageTranslator.js
@@ -344,7 +344,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
 
         const placeholdersElements = root.querySelectorAll('input[placeholder], textarea[placeholder]')
         const altElements = root.querySelectorAll('area[alt], img[alt], input[type="image"][alt]')
-        const valueElements = root.querySelectorAll('input[type="button"], input[type="submit"]')
+        const valueElements = root.querySelectorAll('input[type="button"], input[type="submit"], input[type="reset"]')
         const titleElements = root.querySelectorAll("body [title]")
 
         function hasNoTranslate(elem) {


### PR DESCRIPTION
Input types of reset (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/reset) are currently not translated.
This patch fixes that.