### PR TITLE
[Bugfix] Translate text instead of placeholder

### DIFF
--- a/contentScript/showTranslated.js
+++ b/contentScript/showTranslated.js
@@ -168,6 +168,14 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
         let text
         if (node.nodeName === "INPUT" || node.nodeName === "TEXTAREA") {
             text = node.placeholder
+            if (node.nodeName === "INPUT") {
+                if (node.value !== "") {
+                    text = node.value
+                }
+                else if (node.textContent !== "") {
+                    text = node.textContent
+                }
+            }
             if (node.nodeName === "INPUT" && (node.type === "BUTTON" || node.type === "SUBMIT")) {
                 text = node.value
                 if (!text && node.type === "SUBMIT") {

--- a/contentScript/showTranslated.js
+++ b/contentScript/showTranslated.js
@@ -167,15 +167,17 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
 
         let text
         if (node.nodeName === "INPUT" || node.nodeName === "TEXTAREA") {
-            text = node.placeholder
-            if (node.nodeName === "INPUT") {
-                if (node.value !== "") {
-                    text = node.value
-                }
-                else if (node.textContent !== "") {
-                    text = node.textContent
-                }
+
+            if (node.value !== "") {
+                text = node.value
             }
+            else if (node.textContent !== "") {
+                text = node.textContent
+            }
+            else {
+                text = node.placeholder
+            }
+            
             if (node.nodeName === "INPUT" && (node.type === "BUTTON" || node.type === "SUBMIT")) {
                 text = node.value
                 if (!text && node.type === "SUBMIT") {

--- a/contentScript/showTranslated.js
+++ b/contentScript/showTranslated.js
@@ -168,10 +168,10 @@ Promise.all([twpConfig.onReady(), getTabHostName()])
         let text
         if (node.nodeName === "INPUT" || node.nodeName === "TEXTAREA") {
 
-            if (node.value !== "") {
+            if (node.value) {
                 text = node.value
             }
-            else if (node.textContent !== "") {
+            else if (node.textContent) {
                 text = node.textContent
             }
             else {


### PR DESCRIPTION
Fixes issue #372 

Reorder translation when hovering to set text as node value, then textContent, then placeholder, depending on availability.