### PR TITLE
fix(custom dictionary):  A single word returns directly

### DIFF
--- a/src/contentScript/pageTranslator.js
+++ b/src/contentScript/pageTranslator.js
@@ -93,6 +93,11 @@ async function handleCustomWords(
   try {
     const customDictionary = twpConfig.get("customDictionary");
     if (customDictionary.size > 0) {
+      // If the translation is a single word and exists in the dictionary, return it directly
+      let customValue = customDictionary.get(originalText.trim());
+      if(customValue)
+        return customValue;
+
       translated = removeExtraDelimiter(translated);
       translated = translated.replaceAll(startMark0, startMark);
       translated = translated.replaceAll(endMark0, endMark);


### PR DESCRIPTION
In this page, because an exception was generated and `backgroundTranslateSingleText` was caught and called, my replacement value was not used by `lauch`

https://kotlinlang.org/docs/coroutines-basics.html#an-explicit-job




