### PR TITLE
Add setting to show both original and translated text side by side (inline text)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -206,6 +206,9 @@
   "lblShowTranslatedWhenHoveringThisSite": {
     "message": "Show translation when hovering over this site"
   },
+  "lblShowTextSideBySide": {
+    "message": "Show original and translated text side by side"
+  },
   "lblShowTranslatedWhenHoveringThisLang": {
     "message": "Show translation when hovering over websites in $LANGUAGE_NAME$",
     "placeholders": {

--- a/src/contentScript/pageTranslator.js
+++ b/src/contentScript/pageTranslator.js
@@ -811,8 +811,15 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
   }
 
   function translateTextContent(node, parentNode, text, toRestore) {
-    toRestore.translatedText = text;
+    const isSameText = toRestore.originalText.trim().localeCompare(text.trim()) === 0;
+    const inlineText = isSameText ? text : toRestore.originalText + "\r\n" + text;
+    text = twpConfig.get("showTextSideBySide") === "yes" ? inlineText : text;
+    // Render \r\n properly
+    twpConfig.get("showTextSideBySide") === "yes" && !isSameText ? 
+      parentNode.setAttribute('style', 'white-space: pre-line;') : null;
 
+    toRestore.translatedText = text;
+    
     if (location.hostname === "pdf.translatewebpages.org") {
       if (
         parentNode &&

--- a/src/contentScript/pageTranslator.js
+++ b/src/contentScript/pageTranslator.js
@@ -341,7 +341,13 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
   }
 
   // https://github.com/FilipePS/Traduzir-paginas-web/issues/609
-  if (twpConfig.get("translateTag_pre") !== "yes" && !(document.body.childElementCount === 1 && document.body.firstChild.nodeName.toLocaleLowerCase() === "pre")) {
+  if (
+    twpConfig.get("translateTag_pre") !== "yes" &&
+    !(
+      document.body.childElementCount === 1 &&
+      document.body.firstChild.nodeName.toLocaleLowerCase() === "pre"
+    )
+  ) {
     htmlTagsInlineIgnore.push("pre");
   }
   twpConfig.onChanged((name, newvalue) => {
@@ -351,12 +357,21 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
         if (index !== -1) {
           htmlTagsInlineIgnore.splice(index, 1);
         }
-        if (newvalue !== "yes" && !(document.body.childElementCount === 1 && document.body.firstChild.nodeName.toLocaleLowerCase() === "pre")) {
+        if (
+          newvalue !== "yes" &&
+          !(
+            document.body.childElementCount === 1 &&
+            document.body.firstChild.nodeName.toLocaleLowerCase() === "pre"
+          )
+        ) {
           htmlTagsInlineIgnore.push("pre");
         }
         break;
       case "dontSortResults":
         dontSortResults = newvalue == "yes" ? true : false;
+        break;
+      case "showTextSideBySide":
+        showTextSideBySide = newvalue == "yes" ? true : false;
         break;
     }
   });
@@ -380,6 +395,8 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
   let customDictionary = sortDictionary(twpConfig.get("customDictionary"));
   let dontSortResults =
     twpConfig.get("dontSortResults") == "yes" ? true : false;
+  let showTextSideBySide = twpConfig.get("showTextSideBySide") == "yes";
+
   let fooCount = 0;
 
   let originalPageTitle;
@@ -811,15 +828,21 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
   }
 
   function translateTextContent(node, parentNode, text, toRestore) {
-    const isSameText = toRestore.originalText.trim().localeCompare(text.trim()) === 0;
-    const inlineText = isSameText ? text : toRestore.originalText + "\r\n" + text;
-    text = twpConfig.get("showTextSideBySide") === "yes" ? inlineText : text;
-    // Render \r\n properly
-    twpConfig.get("showTextSideBySide") === "yes" && !isSameText ? 
-      parentNode.setAttribute('style', 'white-space: pre-line;') : null;
+    if (showTextSideBySide) {
+      const isSameText =
+        toRestore.originalText.trim().localeCompare(text.trim()) === 0;
+      const inlineText = isSameText
+        ? text
+        : toRestore.originalText + "\r\n" + text;
+      text = inlineText;
+      // Render \r\n properly
+      if (!isSameText) {
+        parentNode.setAttribute("style", "white-space: pre-line;");
+      }
+    }
 
     toRestore.translatedText = text;
-    
+
     if (location.hostname === "pdf.translatewebpages.org") {
       if (
         parentNode &&
@@ -1216,6 +1239,13 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
     }
   };
 
+  pageTranslator.setShowTextSideBySide = function (_showTextSideBySide) {
+    showTextSideBySide = _showTextSideBySide;
+    if (pageLanguageState === "translated") {
+      pageTranslator.translatePage();
+    }
+  };
+
   let alreadyGotTheLanguage = false;
   const observers = [];
 
@@ -1282,6 +1312,8 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sendResponse(dontSortResults);
     } else if (request.action === "cleanUp") {
       pageTranslator.restorePage();
+    } else if (request.action === "setShowTextSideBySide") {
+      pageTranslator.setShowTextSideBySide(request.showTextSideBySide);
     }
   });
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -6,7 +6,7 @@ const twpConfig = (function () {
   const defaultTargetLanguages = ["en", "es", "de"];
   /**
    * all configName available
-   * @typedef {"uiLanguage" | "pageTranslatorService" | "textTranslatorService" | "enabledServices" | "ttsSpeed" | "targetLanguage" | "targetLanguageTextTranslation" | "targetLanguages" | "alwaysTranslateSites" | "neverTranslateSites" | "sitesToTranslateWhenHovering" | "langsToTranslateWhenHovering" | "alwaysTranslateLangs" | "neverTranslateLangs" | "customDictionary" | "showTranslatePageContextMenu" | "showTranslateSelectedContextMenu" | "showButtonInTheAddressBar" | "showOriginalTextWhenHovering" | "showTranslateSelectedButton" | "showPopupMobile" | "useOldPopup" | "darkMode" | "popupBlueWhenSiteIsTranslated" | "popupPanelSection" | "showReleaseNotes" | "dontShowIfPageLangIsTargetLang" | "dontShowIfPageLangIsUnknown" | "dontShowIfSelectedTextIsTargetLang" | "dontShowIfSelectedTextIsUnknown" | "hotkeys" | "expandPanelTranslateSelectedText" | "translateTag_pre" | "dontSortResults" | "translateDynamicallyCreatedContent" | "autoTranslateWhenClickingALink" | "translateSelectedWhenPressTwice" | "translateTextOverMouseWhenPressTwice" | "translateClickingOnce" | "enableDiskCache" | "useAlternativeService" | "customServices"} DefaultConfigNames
+   * @typedef {"uiLanguage" | "pageTranslatorService" | "textTranslatorService" | "enabledServices" | "ttsSpeed" | "targetLanguage" | "targetLanguageTextTranslation" | "targetLanguages" | "alwaysTranslateSites" | "neverTranslateSites" | "sitesToTranslateWhenHovering" | "langsToTranslateWhenHovering" | "alwaysTranslateLangs" | "neverTranslateLangs" | "customDictionary" | "showTranslatePageContextMenu" | "showTranslateSelectedContextMenu" | "showButtonInTheAddressBar" | "showOriginalTextWhenHovering" | "showTranslateSelectedButton" | "showPopupMobile" | "useOldPopup" | "darkMode" | "popupBlueWhenSiteIsTranslated" | "popupPanelSection" | "showReleaseNotes" | "dontShowIfPageLangIsTargetLang" | "dontShowIfPageLangIsUnknown" | "dontShowIfSelectedTextIsTargetLang" | "dontShowIfSelectedTextIsUnknown" | "hotkeys" | "expandPanelTranslateSelectedText" | "translateTag_pre" | "showTextSideBySide" | "dontSortResults" | "translateDynamicallyCreatedContent" | "autoTranslateWhenClickingALink" | "translateSelectedWhenPressTwice" | "translateTextOverMouseWhenPressTwice" | "translateClickingOnce" | "enableDiskCache" | "useAlternativeService" | "customServices"} DefaultConfigNames
    */
   const defaultConfig = {
     uiLanguage: "default",
@@ -29,6 +29,7 @@ const twpConfig = (function () {
     showButtonInTheAddressBar: "yes",
     showOriginalTextWhenHovering: "no",
     showTranslateSelectedButton: "yes",
+    showTextSideBySide: "no",
     showPopupMobile: "yes", // yes no threeFingersOnTheScreen
     useOldPopup: "yes",
     darkMode: "auto", // auto yes no

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -360,6 +360,14 @@
         </select>
         <br />
         <p>
+          <b data-i18n="lblShowTextSideBySide">Show original and translated text side by side</b>
+        </p>
+        <select id="showTextSideBySide" class="w3-select w3-margin">
+          <option value="no" data-i18n="msgNo">No</option>
+          <option value="yes" data-i18n="msgYes">Yes</option>
+        </select>
+        <br />
+        <p>
           <b data-i18n="lblDontSortResults">Do not sort translation results</b>
         </p>
         <select id="dontSortResults" class="w3-select w3-margin">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -360,14 +360,6 @@
         </select>
         <br />
         <p>
-          <b data-i18n="lblShowTextSideBySide">Show original and translated text side by side</b>
-        </p>
-        <select id="showTextSideBySide" class="w3-select w3-margin">
-          <option value="no" data-i18n="msgNo">No</option>
-          <option value="yes" data-i18n="msgYes">Yes</option>
-        </select>
-        <br />
-        <p>
           <b data-i18n="lblDontSortResults">Do not sort translation results</b>
         </p>
         <select id="dontSortResults" class="w3-select w3-margin">
@@ -584,6 +576,17 @@
           <button id="addDeepL">Add DeepL Free API</button>
           <button id="removeDeepL">Remove DeepL Free API</button>
           <p id="deeplApiResponse"></p>
+        </div>
+        <hr>
+        <div>
+          <br />
+          <p>
+            <b data-i18n="lblShowTextSideBySide">Show original and translated text side by side</b>
+          </p>
+          <select id="showTextSideBySide" class="w3-select w3-margin">
+            <option value="no" data-i18n="msgNo">No</option>
+            <option value="yes" data-i18n="msgYes">Yes</option>
+          </select>
         </div>
       </div>
     </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -636,6 +636,13 @@ twpConfig
       "translateDynamicallyCreatedContent"
     );
 
+    $("#showTextSideBySide").onchange = (e) => {
+      twpConfig.set("showTextSideBySide", e.target.value);
+    };
+    $("#showTextSideBySide").value = twpConfig.get(
+      "showTextSideBySide"
+    );
+
     $("#autoTranslateWhenClickingALink").onchange = (e) => {
       if (e.target.value == "yes") {
         chrome.permissions.request(

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -70,6 +70,14 @@
                     in</label>
             </div>
         </div>
+        <div data-popupPanelSection="7">
+            <hr>
+        </div>
+        <div data-popupPanelSection="7">
+            <input type="checkbox" class="w3-check" id="cbShowTextSideBySide">
+            <label for="cbShowTextSideBySide" data-i18n="lblShowTextSideBySide">Show 
+                original and translated text side by side</label>
+        </div>
     </div>
     </div>
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -44,7 +44,7 @@ twpConfig
       $("#more").style.display = "block";
       $("#less").style.display = "block";
 
-      if (popupPanelSection >= 6) {
+      if (popupPanelSection >= 7) {
         $("#more").style.display = "none";
       } else if (popupPanelSection <= 0) {
         $("#less").style.display = "none";
@@ -53,7 +53,7 @@ twpConfig
     updatePopupSection();
 
     $("#more").onclick = (e) => {
-      if (popupPanelSection < 6) {
+      if (popupPanelSection < 7) {
         popupPanelSection++;
         updatePopupSection();
       }
@@ -458,10 +458,20 @@ twpConfig
           }
         );
 
+        $("#cbShowTextSideBySide").addEventListener("change", (e) => {
+          if (e.target.checked) {
+            twpConfig.set("showTextSideBySide", "yes");
+          } else {
+            twpConfig.set("showTextSideBySide", "no");
+          }
+        });
+
         $("#cbShowTranslateSelectedButton").checked =
           twpConfig.get("showTranslateSelectedButton") == "yes" ? true : false;
         $("#cbShowOriginalWhenHovering").checked =
           twpConfig.get("showOriginalTextWhenHovering") == "yes" ? true : false;
+        $("#cbShowTextSideBySide").checked =
+          twpConfig.get("showTextSideBySide") == "yes" ? true : false;
 
         const hostname = new URL(tabs[0].url).hostname;
         $("#cbAlwaysTranslateThisSite").checked =

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -7,6 +7,7 @@ twpConfig
   .then(() => twpI18n.updateUiMessages())
   .then(() => {
     twpI18n.translateDocument();
+    const popupSectionCount = 7;
 
     $("#btnImproveTranslation").onclick = () => {
       window.location = "improve-translation.html";
@@ -44,7 +45,7 @@ twpConfig
       $("#more").style.display = "block";
       $("#less").style.display = "block";
 
-      if (popupPanelSection >= 7) {
+      if (popupPanelSection >= popupSectionCount) {
         $("#more").style.display = "none";
       } else if (popupPanelSection <= 0) {
         $("#less").style.display = "none";
@@ -53,7 +54,7 @@ twpConfig
     updatePopupSection();
 
     $("#more").onclick = (e) => {
-      if (popupPanelSection < 7) {
+      if (popupPanelSection < popupSectionCount) {
         popupPanelSection++;
         updatePopupSection();
       }
@@ -464,6 +465,23 @@ twpConfig
           } else {
             twpConfig.set("showTextSideBySide", "no");
           }
+
+          chrome.tabs.query(
+            {
+              active: true,
+              currentWindow: true,
+            },
+            (tabs) => {
+              chrome.tabs.sendMessage(
+                tabs[0].id,
+                {
+                  action: "setShowTextSideBySide",
+                  showTextSideBySide: e.target.checked,
+                },
+                checkedLastError
+              );
+            }
+          );
         });
 
         $("#cbShowTranslateSelectedButton").checked =


### PR DESCRIPTION
Using [@Philip-K's PR](https://github.com/FilipePS/Traduzir-paginas-web/pull/404) as the basis for this Pull Request, I am recreating their PR to add a setting to show both the original text and the translated text side by side. My motivation for adding this is to help beginner-intermediate learners of foreign languages by giving them easy access to inline/interlinear text of both their target and native language.

The setting is under Options > More Options > Translations > Show original and translated text side by side. Default is off.

Preview:
Original             |  Translated
:-------------------------:|:-------------------------:
![image](https://github.com/FilipePS/Traduzir-paginas-web/assets/58670498/8644e111-047b-493e-8060-ffe195de2e6f) | ![image](https://github.com/FilipePS/Traduzir-paginas-web/assets/58670498/e778298d-1832-4d98-9368-11d25044f9ef)
