### PR TITLE
Fix not to translate `title` tag

### DIFF
--- a/src/contentScript/pageTranslator.js
+++ b/src/contentScript/pageTranslator.js
@@ -1159,7 +1159,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
     );
     currentPageLanguage = currentTargetLanguage;
 
-    translatePageTitle();
+    //translatePageTitle();
 
     enableMutatinObserver();
 


### PR DESCRIPTION
I wrote detail on https://github.com/FilipePS/Traduzir-paginas-web/issues/733 , `title` tag is intended not to be translated, I think. However, `translatePageTitle()` function exists.
So I disabled `translatePageTitle()`.