### PR TITLE
fix: use onchange instead of oninput for checkbox/select elements (fixes #1000)

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1091,7 +1091,7 @@ twpConfig
     }
 
     // privacy options
-    $("#useAlternativeService").oninput = (e) => {
+    $("#useAlternativeService").onchange = (e) => {
       twpConfig.set("useAlternativeService", e.target.value);
     };
     $("#useAlternativeService").value = twpConfig.get("useAlternativeService");
@@ -1129,7 +1129,7 @@ twpConfig
       ];
 
       servicesInfo.forEach((svInfo) => {
-        $(svInfo.selector).oninput = (e) => {
+        $(svInfo.selector).onchange = (e) => {
           const enabledServices = [];
           let enabledCount = 0;
           servicesInfo.forEach((_svInfo) => {
@@ -1208,7 +1208,7 @@ twpConfig
       }
     };
 
-    $("#enableDiskCache").oninput = (e) => {
+    $("#enableDiskCache").onchange = (e) => {
       twpConfig.set("enableDiskCache", $("#enableDiskCache").value);
     };
     $("#enableDiskCache").value = twpConfig.get("enableDiskCache");


### PR DESCRIPTION
## Summary
Fixes issue #1000 where buttons/options in the extension settings page were not responding to clicks.

## Root Cause
The options page (`src/options/options.js`) used `.oninput` event handlers for:
- `<input type="checkbox">` elements (service enable toggles like DeepL)
- `<select>` dropdown elements ("useAlternativeService", "enableDiskCache")

The `input` event is not standard for checkboxes in some browsers (including Firefox), which prevents the event handler from firing when users click checkboxes or select options. This matches the cross-browser symptoms reported in #1000 (Firefox, Chrome, Ungoogled Chromium, Cromite, Fennec on Android).

## Fix
Changed `.oninput` to `.onchange` for all affected elements:
- `#useAlternativeService` (select)
- `#btnEnableGoogle`, `#btnEnableBing`, `#btnEnableYandex`, `#btnEnableDeepL` (checkboxes)
- `#enableDiskCache` (select)

`onchange` is the standard, cross-browser-compatible event for both `<input type="checkbox">` and `<select>` elements.

## Files Changed
- `src/options/options.js` — 3 line changes (3 deletions, 3 insertions)

## Verification
- No existing test suite in the repository.
- Fix verified by code review: all other checkbox/select handlers in the same file already correctly use `.onchange`.

## AI-assisted
This fix was identified and implemented with AI assistance.

Fixes #1000
