### PR TITLE
Add OpenRouter translation service

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ The pages are translated using the Google, Bing, Yandex, or OpenRouter translati
 
 OpenRouter is optional and disabled by default. To use it, open the extension options, go to the experimental settings, and add your own OpenRouter API key. After the key is added, OpenRouter becomes available in both **Page translation service** and **Text Translation Service**.
 
-OpenRouter uses the `openrouter/auto` model by default, but you can enter a different OpenRouter model ID in the settings. Page translation requests use structured JSON output so translated fragments can be matched back to the original page text in the correct order. API usage may be billed by OpenRouter depending on your account and selected model.
+OpenRouter uses the `google/gemini-3-flash-preview` model by default, but you can enter a different OpenRouter model ID in the settings. Page translation requests use structured JSON output so translated fragments can be matched back to the original page text in the correct order. API usage may be billed by OpenRouter depending on your account and selected model.
 
 **And how's my privacy?**
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 
 # <img src="https://github.com/FilipePS/Traduzir-paginas-web/blob/master/src/icons/icon-128.png" height="50"> Translate Web Pages
 
-Translate your page in real time using Google, Bing or Yandex.
+Translate your page in real time using Google, Bing, Yandex, or an optional OpenRouter provider.
 
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/FilipePS/Traduzir-paginas-web?label=latest%20version&sort=semver)](https://github.com/FilipePS/Traduzir-paginas-web/releases)
 [![GitHub release date](https://img.shields.io/github/release-date/FilipePS/Traduzir-paginas-web?labely)](https://github.com/FilipePS/Traduzir-paginas-web/latest)
@@ -54,11 +54,17 @@ To translate any website it is necessary to access and modify the text of the we
 
 **How are the pages translated?**
 
-The pages are translated using the Google or Yandex translation engine (you choose).
+The pages are translated using the Google, Bing, Yandex, or OpenRouter translation engine (you choose).
+
+**How does OpenRouter support work?**
+
+OpenRouter is optional and disabled by default. To use it, open the extension options, go to the experimental settings, and add your own OpenRouter API key. After the key is added, OpenRouter becomes available in both **Page translation service** and **Text Translation Service**.
+
+OpenRouter uses the `openrouter/auto` model by default, but you can enter a different OpenRouter model ID in the settings. Page translation requests use structured JSON output so translated fragments can be matched back to the original page text in the correct order. API usage may be billed by OpenRouter depending on your account and selected model.
 
 **And how's my privacy?**
 
-[Privacy policy](https://addons.mozilla.org/addon/traduzir-paginas-web/privacy/): We do not collect any information. However, to translate, the contents of the web pages will be sent to Google or Yandex servers.
+[Privacy policy](https://addons.mozilla.org/addon/traduzir-paginas-web/privacy/): We do not collect any information. However, to translate, the contents of the web pages will be sent to the selected translation provider. If OpenRouter is enabled, translated text is sent to OpenRouter and to the model provider selected by OpenRouter.
 
 **Limitations**
 

--- a/src/background/translationService.js
+++ b/src/background/translationService.js
@@ -1536,7 +1536,7 @@ const translationService = (function () {
    * @param {string} model
    * @returns {Service} openrouterService
    */
-  const createOpenRouterService = (apiKey, model = "openrouter/auto") => {
+  const createOpenRouterService = (apiKey, model = "google/gemini-3-flash-preview") => {
     const openrouterTranslationSchema = {
       type: "object",
       properties: {

--- a/src/background/translationService.js
+++ b/src/background/translationService.js
@@ -1530,6 +1530,178 @@ const translationService = (function () {
     })();
   };
 
+  /**
+   * Creates the OpenRouter API translation service.
+   * @param {string} apiKey
+   * @param {string} model
+   * @returns {Service} openrouterService
+   */
+  const createOpenRouterService = (apiKey, model = "openrouter/auto") => {
+    const openrouterTranslationSchema = {
+      type: "object",
+      properties: {
+        translations: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              request_index: {
+                type: "integer",
+              },
+              texts: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+              },
+            },
+            required: ["request_index", "texts"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["translations"],
+      additionalProperties: false,
+    };
+
+    const extractTextFromResponse = (response) => {
+      const content = response?.choices?.[0]?.message?.content;
+      if (typeof content === "string") {
+        return content;
+      }
+
+      if (Array.isArray(content)) {
+        const textBlocks = content
+          .map((part) => part.text || part.content || "")
+          .filter((text) => typeof text === "string");
+        if (textBlocks.length > 0) {
+          return textBlocks.join("");
+        }
+      }
+
+      throw new Error("Unexpected OpenRouter API response");
+    };
+
+    const parseResponseJson = (response) => {
+      const responseText = extractTextFromResponse(response);
+      return typeof responseText === "string"
+        ? JSON.parse(responseText)
+        : responseText;
+    };
+
+    const parseSourceArray = (requestText) => {
+      const sourceArray = JSON.parse(requestText);
+      if (!Array.isArray(sourceArray)) {
+        throw new Error("Unexpected OpenRouter request format");
+      }
+      return sourceArray;
+    };
+
+    const getLanguageName = (languageCode) => {
+      if (languageCode === "auto" || languageCode === "auto-detect") {
+        return "auto-detect";
+      }
+      return twpLang.codeToLanguage(languageCode) || languageCode;
+    };
+
+    return new (class extends Service {
+      constructor() {
+        super(
+          "openrouter",
+          "https://openrouter.ai/api/v1/chat/completions",
+          "POST",
+          function cbTransformRequest(sourceArray) {
+            return JSON.stringify(sourceArray);
+          },
+          function cbParseResponse(response) {
+            const responseJson = parseResponseJson(response);
+            if (!Array.isArray(responseJson?.translations)) {
+              throw new Error("Unexpected OpenRouter API response");
+            }
+
+            return responseJson.translations
+              .sort((a, b) => a.request_index - b.request_index)
+              .map((translation) => ({
+                text: JSON.stringify(translation.texts),
+                detectedLanguage: null,
+              }));
+          },
+          function cbTransformResponse(result, dontSortResults) {
+            return JSON.parse(result);
+          },
+          null,
+          function cbGetRequestBody(sourceLanguage, targetLanguage, requests) {
+            const items = requests.map((request, index) => ({
+              request_index: index,
+              texts: parseSourceArray(request.originalText),
+            }));
+
+            const body = {
+              model,
+              messages: [
+                {
+                  role: "system",
+                  content:
+                    "You are a translation engine. Translate every string in each request to the target language. Return the same request_index values, the same number of strings per request, and the same order. Preserve line breaks, URLs, code-like tokens, placeholders, HTML-like tags, and dictionary markers exactly unless translating the surrounding natural language requires moving them.",
+                },
+                {
+                  role: "user",
+                  content: [
+                    `Source language: ${getLanguageName(sourceLanguage)}`,
+                    `Target language: ${getLanguageName(targetLanguage)}`,
+                    "Translate this JSON payload:",
+                    JSON.stringify({
+                      requests: items,
+                    }),
+                  ].join("\n"),
+                },
+              ],
+              response_format: {
+                type: "json_schema",
+                json_schema: {
+                  name: "translation_batch",
+                  strict: true,
+                  schema: openrouterTranslationSchema,
+                },
+              },
+              provider: {
+                require_parameters: true,
+              },
+              temperature: 0,
+            };
+
+            if (model === "openrouter/auto") {
+              body.plugins = [
+                {
+                  id: "auto-router",
+                  cost_quality_tradeoff: 8,
+                },
+              ];
+            }
+
+            return JSON.stringify(body);
+          },
+          function cbGetExtraHeaders() {
+            return [
+              {
+                name: "Content-Type",
+                value: "application/json",
+              },
+              {
+                name: "Authorization",
+                value: "Bearer " + apiKey,
+              },
+              {
+                name: "X-Title",
+                value: "TWP - Translate Web Pages",
+              },
+            ];
+          }
+        );
+      }
+    })();
+  };
+
   /** @type {Map<string, Service>} */
   const serviceList = new Map();
 
@@ -1708,6 +1880,13 @@ const translationService = (function () {
         "deepl",
         /** @type {Service} */ /** @type {?} */ (deeplService)
       );
+    } else if (request.action === "createOpenRouterService") {
+      serviceList.set(
+        "openrouter",
+        createOpenRouterService(request.openrouter.apiKey, request.openrouter.model)
+      );
+    } else if (request.action === "removeOpenRouterService") {
+      serviceList.delete("openrouter");
     }
   });
 
@@ -1726,6 +1905,16 @@ const translationService = (function () {
         .get("customServices")
         .find((cs) => cs.name === "deepl_freeapi");
       serviceList.set("deepl", createDeeplFreeApiService(deepl_freeapi.apiKey));
+    }
+
+    if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+      const openrouter = twpConfig
+        .get("customServices")
+        .find((cs) => cs.name === "openrouter");
+      serviceList.set(
+        "openrouter",
+        createOpenRouterService(openrouter.apiKey, openrouter.model)
+      );
     }
 
     const proxyServers = twpConfig.get("proxyServers");

--- a/src/contentScript/html/popupMobile.html
+++ b/src/contentScript/html/popupMobile.html
@@ -258,6 +258,7 @@
                         <option value="google">Google</option>
                         <option value="bing">Bing</option>
                         <option value="yandex">Yandex</option>
+                        <option value="openrouter" hidden>OpenRouter</option>
                     </optgroup>
                 </select>
             </div>

--- a/src/contentScript/html/popupMobile.html
+++ b/src/contentScript/html/popupMobile.html
@@ -258,7 +258,7 @@
                         <option value="google">Google</option>
                         <option value="bing">Bing</option>
                         <option value="yandex">Yandex</option>
-                        <option value="openrouter" hidden>OpenRouter</option>
+                        <option value="openrouter" hidden>Gemini (OpenRouter)</option>
                     </optgroup>
                 </select>
             </div>

--- a/src/contentScript/popupMobile.js
+++ b/src/contentScript/popupMobile.js
@@ -34,6 +34,9 @@ void (async function () {
   const bingIcon = await fetch(
     chrome.runtime.getURL("/icons/bing-translate-32.png")
   ).then((response) => response.blob());
+  const openrouterIcon = await fetch(
+    chrome.runtime.getURL("/icons/icon-32.png")
+  ).then((response) => response.blob());
 
   // Load i18n messages based on your language preference
   await twpI18n.updateUiMessages();
@@ -231,6 +234,8 @@ void (async function () {
       serviceIconElement.src = URL.createObjectURL(yandexIcon);
     } else if (service === "bing") {
       serviceIconElement.src = URL.createObjectURL(bingIcon);
+    } else if (service === "openrouter") {
+      serviceIconElement.src = URL.createObjectURL(openrouterIcon);
     }
     serviceIconElement.onload = () => {
       serviceIconElement.onload = null;
@@ -243,6 +248,18 @@ void (async function () {
   const serviceSelector = /** @type {HTMLSelectElement} */ (
     shadowRoot.getElementById("serviceSelector")
   );
+  const updateServiceSelectorOptions = () => {
+    const openrouterOption = serviceSelector.querySelector(
+      `option[value="openrouter"]`
+    );
+    if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+      openrouterOption.removeAttribute("hidden");
+    } else {
+      openrouterOption.setAttribute("hidden", "");
+    }
+  };
+  updateServiceSelectorOptions();
+
   serviceSelector.onclick = () => {
     serviceSelectorIsOpen = true;
     lastInteraction = Date.now();
@@ -693,6 +710,8 @@ void (async function () {
   twpConfig.onChanged((name, newValue) => {
     if (name == "darkMode") {
       updateTheme();
+    } else if (name === "customServices") {
+      updateServiceSelectorOptions();
     }
   });
 })();

--- a/src/contentScript/showTranslated.js
+++ b/src/contentScript/showTranslated.js
@@ -427,6 +427,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
                         <li title="Bing" id="sBing">b</li>
                         <li title="Yandex" id="sYandex">y</li>
                         <li title="DeepL" id="sDeepL" hidden>d</li>
+                        <li title="OpenRouter" id="sOpenRouter" hidden>ai</li>
                         <li title="Listen" data-i18n-title="btnListen" id="listen">
                             <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
                             width="14px" height="12px" viewBox="0 0 93.038 93.038" xml:space="preserve">
@@ -552,6 +553,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
     const sYandex = shadowRoot.getElementById("sYandex");
     const sBing = shadowRoot.getElementById("sBing");
     const sDeepL = shadowRoot.getElementById("sDeepL");
+    const sOpenRouter = shadowRoot.getElementById("sOpenRouter");
 
     sGoogle.onclick = () => {
       currentTextTranslatorService = "google";
@@ -562,6 +564,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sYandex.classList.remove("selected");
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sGoogle.classList.add("selected");
     };
@@ -574,6 +577,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sYandex.classList.remove("selected");
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sYandex.classList.add("selected");
     };
@@ -586,6 +590,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sYandex.classList.remove("selected");
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sBing.classList.add("selected");
     };
@@ -598,8 +603,22 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sYandex.classList.remove("selected");
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sDeepL.classList.add("selected");
+    };
+    sOpenRouter.onclick = () => {
+      currentTextTranslatorService = "openrouter";
+      twpConfig.set("textTranslatorService", "openrouter");
+      translateThisNode(null, true);
+
+      sGoogle.classList.remove("selected");
+      sYandex.classList.remove("selected");
+      sBing.classList.remove("selected");
+      sDeepL.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
+
+      sOpenRouter.classList.add("selected");
     };
 
     const setTargetLanguage = shadowRoot.getElementById("setTargetLanguage");
@@ -668,8 +687,16 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sDeepL.classList.add("selected");
     } else if (currentTextTranslatorService == "bing") {
       sBing.classList.add("selected");
+    } else if (currentTextTranslatorService == "openrouter") {
+      sOpenRouter.classList.add("selected");
     } else {
       sGoogle.classList.add("selected");
+    }
+
+    if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+      sOpenRouter.removeAttribute("hidden");
+    } else {
+      sOpenRouter.setAttribute("hidden", "");
     }
   }
 

--- a/src/contentScript/translateSelected.js
+++ b/src/contentScript/translateSelected.js
@@ -264,6 +264,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
 					<li title="Yandex" id="sYandex">y</li>
 					<li title="DeepL" id="sDeepL" hidden>d</li>
 					<li title="Libretranslate" id="sLibre" hidden>l</li>
+					<li title="OpenRouter" id="sOpenRouter" hidden>ai</li>
 					<li style="opacity: 0; cursor: move;">O</li>
 				</ul>
 			</div>
@@ -397,6 +398,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
     const sBing = shadowRoot.getElementById("sBing");
     const sDeepL = shadowRoot.getElementById("sDeepL");
     const sLibre = shadowRoot.getElementById("sLibre");
+    const sOpenRouter = shadowRoot.getElementById("sOpenRouter");
     const eCopy = shadowRoot.getElementById("copy");
     const eReplace = shadowRoot.getElementById("replace");
     const eListenOriginal = shadowRoot.getElementById("listenOriginal");
@@ -506,6 +508,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sGoogle.classList.add("selected");
     };
@@ -519,6 +522,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sYandex.classList.add("selected");
     };
@@ -532,6 +536,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sBing.classList.add("selected");
     };
@@ -551,6 +556,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
         sBing.classList.remove("selected");
         sDeepL.classList.remove("selected");
         sLibre.classList.remove("selected");
+        sOpenRouter.classList.remove("selected");
 
         sDeepL.classList.add("selected");
       }
@@ -565,8 +571,23 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sLibre.classList.add("selected");
+    };
+    sOpenRouter.onclick = () => {
+      currentTextTranslatorService = "openrouter";
+      twpConfig.set("textTranslatorService", "openrouter");
+      translateNewInput();
+
+      sGoogle.classList.remove("selected");
+      sYandex.classList.remove("selected");
+      sBing.classList.remove("selected");
+      sDeepL.classList.remove("selected");
+      sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
+
+      sOpenRouter.classList.add("selected");
     };
 
     const setTargetLanguage = shadowRoot.getElementById("setTargetLanguage");
@@ -675,6 +696,8 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sBing.classList.add("selected");
     } else if (currentTextTranslatorService == "libre") {
       sLibre.classList.add("selected");
+    } else if (currentTextTranslatorService == "openrouter") {
+      sOpenRouter.classList.add("selected");
     } else {
       sGoogle.classList.add("selected");
     }
@@ -704,6 +727,11 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       sLibre.removeAttribute("hidden");
     } else {
       sLibre.setAttribute("hidden", "");
+    }
+    if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+      sOpenRouter.removeAttribute("hidden");
+    } else {
+      sOpenRouter.setAttribute("hidden", "");
     }
 
     if (
@@ -754,6 +782,11 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
             sLibre.removeAttribute("hidden");
           } else {
             sLibre.setAttribute("hidden", "");
+          }
+          if (newvalue.find((cs) => cs.name === "openrouter")) {
+            sOpenRouter.removeAttribute("hidden");
+          } else {
+            sOpenRouter.setAttribute("hidden", "");
           }
           break;
         }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -10,8 +10,8 @@ const twpConfig = (function () {
    */
   const defaultConfig = {
     uiLanguage: "default",
-    pageTranslatorService: "google", // google yandex bing
-    textTranslatorService: "google", // google yandex bing deepl
+    pageTranslatorService: "google", // google yandex bing openrouter
+    textTranslatorService: "google", // google yandex bing deepl libre openrouter
     textToSpeechService: "google", // google bing
     enabledServices: ["google", "bing", "yandex", "deepl"],
     ttsSpeed: 1.0,
@@ -553,10 +553,14 @@ const twpConfig = (function () {
    * @returns {string} newServiceName
    */
   twpConfig.swapPageTranslationService = function () {
-    const pageTranslationServices = ["google", "bing", "yandex"];
+    const builtinPageTranslationServices = ["google", "bing", "yandex"];
     const pageEnabledServices = twpConfig
       .get("enabledServices")
-      .filter((svName) => pageTranslationServices.includes(svName));
+      .filter((svName) => builtinPageTranslationServices.includes(svName));
+    if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+      pageEnabledServices.push("openrouter");
+    }
+
     const index = pageEnabledServices.indexOf(
       twpConfig.get("pageTranslatorService")
     );

--- a/src/lib/languages.js
+++ b/src/lib/languages.js
@@ -12227,6 +12227,7 @@ const twpLang = (function () {
 
   twpLang.UILanguages = Object.keys(allLanguagesNames);
   twpLang.TargetLanguages = Object.keys(allLanguagesNames["en"]);
+  twpLang.SupportedLanguages.openrouter = [...twpLang.TargetLanguages];
 
   /**
    * get the list of localized languages for the current browser language
@@ -12243,7 +12244,7 @@ const twpLang = (function () {
 
   /** @type {Map<string, string>} */
   const alternatives = new Map();
-  const pageTranslationServices = ["google", "bing", "yandex"];
+  const pageTranslationServices = ["google", "bing", "yandex", "openrouter"];
   /**
    * gets an alternate translation service if the selected translation service does not support the current target language.
    * @param {string} lang

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -290,7 +290,7 @@
             <option value="google">Google</option>
             <option value="bing">Bing</option>
             <option value="yandex">Yandex</option>
-            <option value="openrouter" disabled>OpenRouter</option>
+            <option value="openrouter" disabled>Gemini (OpenRouter)</option>
           </select>
           <br />
           <p>
@@ -301,7 +301,7 @@
             <option value="bing">Bing</option>
             <option value="yandex">Yandex</option>
             <option value="deepl">DeepL</option>
-            <option value="openrouter" disabled>OpenRouter</option>
+            <option value="openrouter" disabled>Gemini (OpenRouter)</option>
           </select>
           <br />
           <p>
@@ -605,17 +605,17 @@
         </div>
         <hr>
         <div>
-          <h3>Configure an OpenRouter API key to translate text and pages.</h3>
+          <h3>Configure an OpenRouter API key to translate text and pages with Gemini.</h3>
           <label for="openrouterKEY">Your API key</label><br>
           <input type="text" id="openrouterKEY" placeholder="sk-or-v1-..." style="width: 90%;"
             autocomplete="off" spellcheck="false"><br>
           <br>
           <label for="openrouterModel">Model</label><br>
-          <input type="text" id="openrouterModel" placeholder="openrouter/auto" style="width: 90%;"
+          <input type="text" id="openrouterModel" placeholder="google/gemini-3-flash-preview" style="width: 90%;"
             autocomplete="off" spellcheck="false"><br>
           <br>
-          <button id="addOpenRouter">Add OpenRouter</button>
-          <button id="removeOpenRouter">Remove OpenRouter</button>
+          <button id="addOpenRouter">Add Gemini (OpenRouter)</button>
+          <button id="removeOpenRouter">Remove Gemini (OpenRouter)</button>
           <p id="openrouterApiResponse"></p>
         </div>
         <hr>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -290,6 +290,7 @@
             <option value="google">Google</option>
             <option value="bing">Bing</option>
             <option value="yandex">Yandex</option>
+            <option value="openrouter" disabled>OpenRouter</option>
           </select>
           <br />
           <p>
@@ -300,6 +301,7 @@
             <option value="bing">Bing</option>
             <option value="yandex">Yandex</option>
             <option value="deepl">DeepL</option>
+            <option value="openrouter" disabled>OpenRouter</option>
           </select>
           <br />
           <p>
@@ -600,6 +602,21 @@
           <button id="addDeepL">Add DeepL Free API</button>
           <button id="removeDeepL">Remove DeepL Free API</button>
           <p id="deeplApiResponse"></p>
+        </div>
+        <hr>
+        <div>
+          <h3>Configure an OpenRouter API key to translate text and pages.</h3>
+          <label for="openrouterKEY">Your API key</label><br>
+          <input type="text" id="openrouterKEY" placeholder="sk-or-v1-..." style="width: 90%;"
+            autocomplete="off" spellcheck="false"><br>
+          <br>
+          <label for="openrouterModel">Model</label><br>
+          <input type="text" id="openrouterModel" placeholder="openrouter/auto" style="width: 90%;"
+            autocomplete="off" spellcheck="false"><br>
+          <br>
+          <button id="addOpenRouter">Add OpenRouter</button>
+          <button id="removeOpenRouter">Remove OpenRouter</button>
+          <p id="openrouterApiResponse"></p>
         </div>
         <hr>
         <div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1096,30 +1096,62 @@ twpConfig
     };
     $("#useAlternativeService").value = twpConfig.get("useAlternativeService");
 
+    const customTextServiceNames = ["libre", "openrouter"];
+    const customPageServiceNames = ["openrouter"];
+    const getAvailablePageServices = (enabledServices) => [
+      ...enabledServices,
+      ...twpConfig
+        .get("customServices")
+        .filter((cs) => customPageServiceNames.includes(cs.name))
+        .map((cs) => cs.name),
+    ];
+    const getAvailableTextServices = (enabledServices) => [
+      ...enabledServices,
+      ...twpConfig
+        .get("customServices")
+        .filter((cs) => customTextServiceNames.includes(cs.name))
+        .map((cs) => cs.name),
+    ];
+    const isOpenRouterConfigured = () =>
+      twpConfig.get("customServices").find((cs) => cs.name === "openrouter");
+    const updateOpenRouterServiceOption = (selector) => {
+      const option = $(`${selector} option[value="openrouter"]`);
+      if (!option) return;
+
+      option.removeAttribute("hidden");
+      if (isOpenRouterConfigured()) {
+        option.removeAttribute("disabled");
+      } else {
+        option.setAttribute("disabled", "");
+      }
+    };
+    const updateServiceSelector = (enabledServices) => {
+      document
+        .querySelectorAll("#pageTranslatorService option")
+        .forEach((option) => option.setAttribute("hidden", ""));
+      document
+        .querySelectorAll("#textTranslatorService option")
+        .forEach((option) => option.setAttribute("hidden", ""));
+      getAvailablePageServices(enabledServices).forEach((svName) => {
+        const option = $(`#pageTranslatorService option[value="${svName}"]`);
+        if (option) {
+          option.removeAttribute("hidden");
+        }
+      });
+      getAvailableTextServices(enabledServices).forEach((svName) => {
+        const option = $(`#textTranslatorService option[value="${svName}"]`);
+        if (option) {
+          option.removeAttribute("hidden");
+        }
+      });
+      updateOpenRouterServiceOption("#pageTranslatorService");
+      updateOpenRouterServiceOption("#textTranslatorService");
+    };
+
     {
       if (platformInfo.isMobile.any) {
         $("#btnEnableDeepL").setAttribute("disabled", "");
       }
-
-      const updateServiceSelector = (enabledServices) => {
-        document
-          .querySelectorAll("#pageTranslatorService option")
-          .forEach((option) => option.setAttribute("hidden", ""));
-        document
-          .querySelectorAll("#textTranslatorService option")
-          .forEach((option) => option.setAttribute("hidden", ""));
-        enabledServices.forEach((svName) => {
-          let option;
-          option = $(`#pageTranslatorService option[value="${svName}"]`);
-          if (option) {
-            option.removeAttribute("hidden");
-          }
-          option = $(`#textTranslatorService option[value="${svName}"]`);
-          if (option) {
-            option.removeAttribute("hidden");
-          }
-        });
-      };
 
       const servicesInfo = [
         { selector: "#btnEnableGoogle", svName: "google" },
@@ -1153,13 +1185,15 @@ twpConfig
             }
           });
 
-          if (
-            !enabledServices.includes(twpConfig.get("textTranslatorService"))
-          ) {
+          if (!getAvailableTextServices(enabledServices).includes(
+            twpConfig.get("textTranslatorService")
+          )) {
             twpConfig.set("textTranslatorService", enabledServices[0]);
           }
           if (
-            !enabledServices.includes(twpConfig.get("pageTranslatorService"))
+            !getAvailablePageServices(enabledServices).includes(
+              twpConfig.get("pageTranslatorService")
+            )
           ) {
             twpConfig.set("pageTranslatorService", enabledServices[0]);
           }
@@ -1460,6 +1494,190 @@ twpConfig
       testDeepLFreeApiKey(deepl_freeapi.apiKey).then((response) => {
         $("#deeplApiResponse").textContent = JSON.stringify(response);
       });
+    }
+
+    async function testOpenRouterApiKey(apiKey, model) {
+      return await new Promise((resolve, reject) => {
+        const xhttp = new XMLHttpRequest();
+        xhttp.open(
+          "POST",
+          "https://openrouter.ai/api/v1/chat/completions"
+        );
+        xhttp.responseType = "json";
+        xhttp.setRequestHeader("Content-Type", "application/json");
+        xhttp.setRequestHeader("Authorization", "Bearer " + apiKey);
+        xhttp.setRequestHeader("X-Title", "TWP - Translate Web Pages");
+        xhttp.onload = () => {
+          if (xhttp.status >= 200 && xhttp.status < 300) {
+            resolve(xhttp.response);
+          } else {
+            reject(xhttp.response || new Error("Invalid OpenRouter API key"));
+          }
+        };
+        xhttp.onerror = () => reject(new Error("Could not reach OpenRouter API"));
+
+        const body = {
+          model,
+          messages: [
+            {
+              role: "system",
+              content:
+                "You are a translation engine. Return the requested JSON shape.",
+            },
+            {
+              role: "user",
+              content:
+                'Translate this JSON payload to English: {"requests":[{"request_index":0,"texts":["olá"]}]}',
+            },
+          ],
+          response_format: {
+            type: "json_schema",
+            json_schema: {
+              name: "translation_batch",
+              strict: true,
+              schema: {
+                type: "object",
+                properties: {
+                  translations: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        request_index: {
+                          type: "integer",
+                        },
+                        texts: {
+                          type: "array",
+                          items: {
+                            type: "string",
+                          },
+                        },
+                      },
+                      required: ["request_index", "texts"],
+                      additionalProperties: false,
+                    },
+                  },
+                },
+                required: ["translations"],
+                additionalProperties: false,
+              },
+            },
+          },
+          provider: {
+            require_parameters: true,
+          },
+          temperature: 0,
+        };
+
+        if (model === "openrouter/auto") {
+          body.plugins = [
+            {
+              id: "auto-router",
+              cost_quality_tradeoff: 8,
+            },
+          ];
+        }
+
+        xhttp.send(JSON.stringify(body));
+      });
+    }
+
+    $("#addOpenRouter").onclick = async () => {
+      const openrouter = {
+        name: "openrouter",
+        apiKey: $("#openrouterKEY").value.trim(),
+        model: $("#openrouterModel").value.trim() || "openrouter/auto",
+      };
+      try {
+        if (openrouter.apiKey.length < 10) {
+          throw new Error("Provides an API Key");
+        }
+
+        const response = await testOpenRouterApiKey(openrouter.apiKey, openrouter.model);
+        $("#openrouterApiResponse").textContent = JSON.stringify(response);
+        if (response) {
+          const customServices = twpConfig.get("customServices");
+
+          const index = customServices.findIndex((cs) => cs.name === "openrouter");
+          if (index !== -1) {
+            customServices.splice(index, 1);
+          }
+
+          customServices.push(openrouter);
+          twpConfig.set("customServices", customServices);
+          chrome.runtime.sendMessage({
+            action: "createOpenRouterService",
+            openrouter,
+          });
+          updateServiceSelector(twpConfig.get("enabledServices"));
+          twpConfig.set("textTranslatorService", "openrouter");
+          twpConfig.set("pageTranslatorService", "openrouter");
+          $("#pageTranslatorService").value = "openrouter";
+          $("#textTranslatorService").value = "openrouter";
+        } else {
+          alert("Invalid API key");
+        }
+      } catch (e) {
+        $("#openrouterApiResponse").textContent = JSON.stringify(e);
+        alert(e);
+      }
+    };
+
+    $("#removeOpenRouter").onclick = () => {
+      const customServices = twpConfig.get("customServices");
+      const index = customServices.findIndex((cs) => cs.name === "openrouter");
+      if (index !== -1) {
+        customServices.splice(index, 1);
+        twpConfig.set("customServices", customServices);
+        chrome.runtime.sendMessage(
+          { action: "removeOpenRouterService" },
+          checkedLastError
+        );
+      }
+
+      if (twpConfig.get("pageTranslatorService") === "openrouter") {
+        chrome.runtime.sendMessage(
+          {
+            action: "restorePagesWithServiceNames",
+            serviceNames: ["openrouter"],
+            newServiceName: twpConfig.get("enabledServices")[0],
+          },
+          checkedLastError
+        );
+        twpConfig.set(
+          "pageTranslatorService",
+          twpConfig.get("enabledServices")[0]
+        );
+        $("#pageTranslatorService").value = twpConfig.get(
+          "pageTranslatorService"
+        );
+      }
+
+      if (twpConfig.get("textTranslatorService") === "openrouter") {
+        twpConfig.set(
+          "textTranslatorService",
+          twpConfig.get("pageTranslatorService")
+        );
+        $("#textTranslatorService").value = twpConfig.get(
+          "textTranslatorService"
+        );
+      }
+
+      updateServiceSelector(twpConfig.get("enabledServices"));
+      $("#openrouterKEY").value = "";
+      $("#openrouterModel").value = "openrouter/auto";
+      $("#openrouterApiResponse").textContent = "";
+    };
+
+    const openrouter = twpConfig
+      .get("customServices")
+      .find((cs) => cs.name === "openrouter");
+    if (openrouter) {
+      $("#openrouterKEY").value = openrouter.apiKey;
+      $("#openrouterModel").value = openrouter.model || "openrouter/auto";
+      updateServiceSelector(twpConfig.get("enabledServices"));
+    } else {
+      $("#openrouterModel").value = "openrouter/auto";
     }
 
     $("#showMobilePopupOnDesktop").onchange = (e) => {

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1586,7 +1586,7 @@ twpConfig
       const openrouter = {
         name: "openrouter",
         apiKey: $("#openrouterKEY").value.trim(),
-        model: $("#openrouterModel").value.trim() || "openrouter/auto",
+        model: $("#openrouterModel").value.trim() || "google/gemini-3-flash-preview",
       };
       try {
         if (openrouter.apiKey.length < 10) {
@@ -1665,7 +1665,7 @@ twpConfig
 
       updateServiceSelector(twpConfig.get("enabledServices"));
       $("#openrouterKEY").value = "";
-      $("#openrouterModel").value = "openrouter/auto";
+      $("#openrouterModel").value = "google/gemini-3-flash-preview";
       $("#openrouterApiResponse").textContent = "";
     };
 
@@ -1674,10 +1674,10 @@ twpConfig
       .find((cs) => cs.name === "openrouter");
     if (openrouter) {
       $("#openrouterKEY").value = openrouter.apiKey;
-      $("#openrouterModel").value = openrouter.model || "openrouter/auto";
+      $("#openrouterModel").value = openrouter.model || "google/gemini-3-flash-preview";
       updateServiceSelector(twpConfig.get("enabledServices"));
     } else {
-      $("#openrouterModel").value = "openrouter/auto";
+      $("#openrouterModel").value = "google/gemini-3-flash-preview";
     }
 
     $("#showMobilePopupOnDesktop").onchange = (e) => {

--- a/src/popup/improve-translation.html
+++ b/src/popup/improve-translation.html
@@ -127,7 +127,7 @@
       <option value="google">Google</option>
       <option value="bing">Bing</option>
       <option value="yandex">Yandex</option>
-      <option value="openrouter" hidden>OpenRouter</option>
+      <option value="openrouter" hidden>Gemini (OpenRouter)</option>
     </select>
     <br>
   </div>

--- a/src/popup/improve-translation.html
+++ b/src/popup/improve-translation.html
@@ -127,6 +127,7 @@
       <option value="google">Google</option>
       <option value="bing">Bing</option>
       <option value="yandex">Yandex</option>
+      <option value="openrouter" hidden>OpenRouter</option>
     </select>
     <br>
   </div>

--- a/src/popup/improve-translation.js
+++ b/src/popup/improve-translation.js
@@ -34,6 +34,16 @@ twpConfig
   .then(() => {
     twpI18n.translateDocument();
 
+    const updatePageServiceSelector = () => {
+      const openrouterOption = $(`#pageTranslatorService option[value="openrouter"]`);
+      if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+        openrouterOption.removeAttribute("hidden");
+      } else {
+        openrouterOption.setAttribute("hidden", "");
+      }
+    };
+    updatePageServiceSelector();
+
     $("#pageTranslatorService").value = twpConfig.get("pageTranslatorService");
     $("#dontSortResults").value = twpConfig.get("dontSortResults");
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/src/popup/old-popup.js
+++ b/src/popup/old-popup.js
@@ -277,6 +277,10 @@ twpConfig
         $("#btnOptions option[value='translateInExternalSite']").textContent =
           twpI18n.getMessage("btnOpenOnGoogleTranslate");
         $("#iconTranslate").setAttribute("src", "/icons/bing-translate-32.png");
+      } else if (currentPageTranslatorService == "openrouter") {
+        $("#btnOptions option[value='translateInExternalSite']").textContent =
+          twpI18n.getMessage("btnOpenOnGoogleTranslate");
+        $("#iconTranslate").setAttribute("src", "/icons/icon-32.png");
       } else {
         // google
         $("#btnOptions option[value='translateInExternalSite']").textContent =

--- a/src/popup/popup-translate-text.html
+++ b/src/popup/popup-translate-text.html
@@ -118,6 +118,7 @@
         <li title="Yandex" id="sYandex">y</li>
         <li title="DeepL" id="sDeepL" hidden>d</li>
         <li title="libre" id="sLibre" hidden>l</li>
+        <li title="OpenRouter" id="sOpenRouter" hidden>ai</li>
       </ul>
       <ul>
         <li title="Copy" data-i18n-title="btncopy" id="copy">

--- a/src/popup/popup-translate-text.js
+++ b/src/popup/popup-translate-text.js
@@ -152,6 +152,7 @@ twpConfig
     const sBing = document.getElementById("sBing");
     const sDeepL = document.getElementById("sDeepL");
     const sLibre = document.getElementById("sLibre");
+    const sOpenRouter = document.getElementById("sOpenRouter");
     const eCopy = document.getElementById("copy");
     const eListenOriginal = document.getElementById("listenOriginal");
     const eListenTranslated = document.getElementById("listenTranslated");
@@ -194,6 +195,7 @@ twpConfig
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sGoogle.classList.add("selected");
     };
@@ -207,6 +209,7 @@ twpConfig
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sYandex.classList.add("selected");
     };
@@ -220,6 +223,7 @@ twpConfig
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sBing.classList.add("selected");
     };
@@ -233,6 +237,7 @@ twpConfig
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sDeepL.classList.add("selected");
     };
@@ -246,8 +251,23 @@ twpConfig
       sBing.classList.remove("selected");
       sDeepL.classList.remove("selected");
       sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
 
       sLibre.classList.add("selected");
+    };
+    sOpenRouter.onclick = () => {
+      currentTextTranslatorService = "openrouter";
+      twpConfig.set("textTranslatorService", "openrouter");
+      translateText();
+
+      sGoogle.classList.remove("selected");
+      sYandex.classList.remove("selected");
+      sBing.classList.remove("selected");
+      sDeepL.classList.remove("selected");
+      sLibre.classList.remove("selected");
+      sOpenRouter.classList.remove("selected");
+
+      sOpenRouter.classList.add("selected");
     };
 
     const setTargetLanguage = document.getElementById("setTargetLanguage");
@@ -350,6 +370,10 @@ twpConfig
         break;
       case "libre":
         sLibre.classList.add("selected");
+        break;
+      case "openrouter":
+        sOpenRouter.classList.add("selected");
+        break;
       default:
         sGoogle.classList.add("selected");
         break;
@@ -380,6 +404,11 @@ twpConfig
       sLibre.removeAttribute("hidden");
     } else {
       sLibre.setAttribute("hidden", "");
+    }
+    if (twpConfig.get("customServices").find((cs) => cs.name === "openrouter")) {
+      sOpenRouter.removeAttribute("hidden");
+    } else {
+      sOpenRouter.setAttribute("hidden", "");
     }
 
     twpConfig.onChanged((name, newvalue) => {
@@ -413,6 +442,11 @@ twpConfig
             sLibre.removeAttribute("hidden");
           } else {
             sLibre.setAttribute("hidden", "");
+          }
+          if (newvalue.find((cs) => cs.name === "openrouter")) {
+            sOpenRouter.removeAttribute("hidden");
+          } else {
+            sOpenRouter.setAttribute("hidden", "");
           }
           break;
         }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -252,6 +252,10 @@ twpConfig
         $("#btnOptions option[value='translateInExternalSite']").textContent =
           twpI18n.getMessage("btnOpenOnGoogleTranslate");
         $("#iconTranslate").setAttribute("src", "/icons/bing-translate-32.png");
+      } else if (currentPageTranslatorService == "openrouter") {
+        $("#btnOptions option[value='translateInExternalSite']").textContent =
+          twpI18n.getMessage("btnOpenOnGoogleTranslate");
+        $("#iconTranslate").setAttribute("src", "/icons/icon-32.png");
       } else {
         // google
         $("#btnOptions option[value='translateInExternalSite']").textContent =


### PR DESCRIPTION
## Summary

- Adds an optional OpenRouter translation provider for the MV3 branch (because I use Brave)
- Supports both page translation and selected/text translation.
- Stores a user-provided OpenRouter API key in the existing custom service configuration flow.
- Uses `openrouter/auto` by default, while allowing users to enter another OpenRouter model ID.
- Uses OpenRouter structured outputs with `response_format: { type: "json_schema" }` so page translation batches return predictable `{ request_index, texts }` results.
- Shows OpenRouter in the page/text service dropdowns, disabled until an API key is configured.
- Documents the feature, privacy path, and possible OpenRouter billing in the README.

## Why

This gives users an opt-in way to translate through OpenRouter without hardcoding a provider-specific API key or model. Page translation needs more than plain text output because translated fragments must be mapped back to the original page nodes in order; this implementation asks OpenRouter for strict JSON schema output and validates/parses that structure before returning translations to the existing page translator.

## Implementation Notes

- OpenRouter requests use `https://openrouter.ai/api/v1/chat/completions`.
- Requests include `Authorization: Bearer <user key>` and no bundled/shared key.
- Requests set `provider.require_parameters: true` so OpenRouter should route only to providers that support the requested structured-output parameters.
- The `openrouter/auto` default includes the auto-router plugin with a cost-oriented tradeoff.
- OpenRouter is treated as a custom service and is unavailable until configured.

## Validation

- `node --check` on the edited background, options, content script, and popup JavaScript files.
- `npm run build`.
- Loaded `build/TWP_10.1.5.1_Chromium` in Brave with a temporary profile.
- Confirmed the MV3 service worker starts.
- Confirmed OpenRouter is recognized as page-capable by `twpLang.getAlternativeService("en", "openrouter", true)`.
- Confirmed Options shows OpenRouter in both page and text service dropdowns, disabled before configuration.
- Manually tested in Brave, it works with `google/gemini-3-flash-preview`

## Caution

Not all Openrouter models / providers may support JSON structured output.