### PR TITLE
feat: Add hotkey to toggle hover translation for the current tab

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -596,5 +596,8 @@
   },
   "btnChangePosition": {
     "message": "Change position"
+  },
+  "lblToggleHoverCurrentTab": {
+    "message": "Toggle hover translation for current tab"
   }
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -984,6 +984,21 @@ if (typeof chrome.commands !== "undefined") {
             checkedLastError
           )
       );
+    } else if (command === "hotkey-toggle-hover-current-tab") {
+      chrome.tabs.query(
+        {
+          currentWindow: true,
+          active: true,
+        },
+        (tabs) =>
+          chrome.tabs.sendMessage(
+            tabs[0].id,
+            {
+              action: "ToggleHoverCurrentTab",
+            },
+            checkedLastError
+          )
+      );
     } else if (command === "hotkey-swap-page-translation-service") {
       chrome.tabs.query(
         {

--- a/src/chrome_manifest.json
+++ b/src/chrome_manifest.json
@@ -40,6 +40,12 @@
     },
     "hotkey-hot-translate-selected-text": {
       "description": "__MSG_lblHotTranslatedSelectedText__"
+    },
+    "hotkey-toggle-hover-current-tab": {
+      "suggested_key": {
+        "default": "Shift+Alt+H"
+      },
+      "description": "__MSG_lblToggleHoverCurrentTab__"
     }
   },
   "icons": {

--- a/src/contentScript/showTranslated.js
+++ b/src/contentScript/showTranslated.js
@@ -34,7 +34,26 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
   let showTranslatedTextWhenHoveringThisLang = false;
   let translateTextOverMouseWhenPressTwice =
     twpConfig.get("translateTextOverMouseWhenPressTwice") === "yes";
+  let tabHoverOverride = null;
   let fooCount = 0;
+
+  function isHoverTranslationEnabled() {
+    if (tabHoverOverride !== null) {
+      return tabHoverOverride;
+    }
+    return showTranslatedTextWhenHoveringThisSite || showTranslatedTextWhenHoveringThisLang;
+  }
+
+  chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+    if (request.action === "ToggleHoverCurrentTab") {
+      if (tabHoverOverride === null) {
+        tabHoverOverride = !isHoverTranslationEnabled();
+      } else {
+        tabHoverOverride = !tabHoverOverride;
+      }
+      updateEventListener();
+    }
+  });
 
   twpConfig.onChanged(function (name, newValue) {
     switch (name) {
@@ -143,12 +162,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
     if (e.target === currentNodeOverMouse) return;
     currentNodeOverMouse = e.target;
 
-    if (
-      !(
-        !showTranslatedTextWhenHoveringThisSite &&
-        !showTranslatedTextWhenHoveringThisLang
-      )
-    ) {
+    if (isHoverTranslationEnabled()) {
       destroy();
       if (e.buttons === 0) {
         timeoutHandler = setTimeout(translateThisNode, 1250, e.target);
@@ -741,8 +755,7 @@ Promise.all([twpConfig.onReady(), getTabHostName()]).then(function (_) {
       platformInfo.isMobile.any ||
       pageLanguageState == "translated" ||
       !(
-        showTranslatedTextWhenHoveringThisSite ||
-        showTranslatedTextWhenHoveringThisLang ||
+        isHoverTranslationEnabled() ||
         translateTextOverMouseWhenPressTwice
       )
     ) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -59,6 +59,12 @@
         "default": "Ctrl+Alt+X"
       },
       "description": "__MSG_lblHotTranslatedSelectedText__"
+    },
+    "hotkey-toggle-hover-current-tab": {
+      "suggested_key": {
+        "default": "Shift+Alt+H"
+      },
+      "description": "__MSG_lblToggleHoverCurrentTab__"
     }
   },
   "icons": {


### PR DESCRIPTION
# Add hotkey to toggle hover translation for the current tab

## Problem
Users who value privacy often keep "Hover translation" disabled to prevent the extension from silently sending hovered text to external translation services on privacy-sensitive pages. However, when they visit a trusted page (like a foreign news article), they are forced to use the "Translate text over mouse when press twice" feature, which is finger-straining if they want to read multiple paragraphs comfortably.

## Solution
This PR introduces a new customizable command (`hotkey-toggle-hover-current-tab`, default `Shift+Alt+H`) that temporarily enables hover-translation strictly for the **current tab**. 

* If hover-translation is off by default, pressing the hotkey allows the user to hover and translate freely on that specific page.
* Because the state is stored at the tab level, if the user closes the tab or refreshes, the state resets. This guarantees that hover translation remains strictly opt-in per session, maximizing privacy.

## Implementation Details
This is implemented non-intrusively without adding new global configuration or UI settings:
* **`manifest.json`**: Registers the new command `"hotkey-toggle-hover-current-tab"`.
* **`messages.json`**: Adds the display text `"Toggle hover translation for current tab"`.
* **`background.js`**: Listens for the command and routes a `"ToggleHoverCurrentTab"` message strictly to the active tab.
* **`showTranslated.js`**: Stores a local `isTabHoverOverrideOn` variable. When toggled, it calls `updateEventListener()` and activates the `onMouseMove` translation timeout as if the site was whitelisted.